### PR TITLE
Enable usage on stable rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: rust
 rust:
   - stable
   - beta
-  - nightly
 matrix:
-  allow_failures:
-    - rust: stable
-    - rust: beta
+  include:
+    - rust: nightly
+      env: CARGO_TEST_FLAGS="--features bench"
+script: cargo test --verbose $CARGO_TEST_FLAGS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ log = "0.4"
 quickcheck = "0.8"
 obj-rs = "0.4"
 
+[features]
+default = ["nightly"]
+nightly = []
+
 [profile.release]
 lto = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,7 @@ quickcheck = "0.8"
 obj-rs = "0.4"
 
 [features]
-default = ["nightly"]
-nightly = []
+bench = []
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -187,3 +187,7 @@ which has a maximum offset distance for shapes. This simulates a more realistic 
 We also see that the *Sponza* scene by itself contains some structures which can be tightly wrapped in a BVH.
 By mowing those structures around we destroy the locality of the triangle groups which leads to more branches in the
 BVH requiring a check, thus leading to a higher intersection duration.
+
+### Running the benchmark suite
+The benchmark suite uses features from the [test crate](https://doc.rust-lang.org/unstable-book/library-features/test.html) and therefore cannot be run on stable rust.
+Using a nightly toolchain, run with `cargo test --features bench` to enable them.

--- a/src/bvh/bvh.rs
+++ b/src/bvh/bvh.rs
@@ -700,13 +700,9 @@ impl BoundingHierarchy for BVH {
 }
 
 #[cfg(test)]
-pub mod tests {
+mod tests {
     use bvh::BVH;
-    use testbase::{
-        build_1200_triangles_bh, build_120k_triangles_bh, build_12k_triangles_bh, build_some_bh,
-        intersect_1200_triangles_bh, intersect_120k_triangles_bh, intersect_12k_triangles_bh,
-        intersect_bh, load_sponza_scene, traverse_some_bh,
-    };
+    use testbase::{build_some_bh, traverse_some_bh};
 
     #[test]
     /// Tests whether the building procedure succeeds in not failing.
@@ -719,6 +715,16 @@ pub mod tests {
     fn test_traverse_bvh() {
         traverse_some_bh::<BVH>();
     }
+}
+
+#[cfg(all(features = "nightly", test))]
+mod bench {
+    use bvh::BVH;
+    use testbase::{
+        build_1200_triangles_bh, build_120k_triangles_bh, build_12k_triangles_bh, build_some_bh,
+        intersect_1200_triangles_bh, intersect_120k_triangles_bh, intersect_12k_triangles_bh,
+        intersect_bh, load_sponza_scene, traverse_some_bh,
+    };
 
     #[bench]
     /// Benchmark the construction of a `BVH` with 1,200 triangles.

--- a/src/bvh/optimization.rs
+++ b/src/bvh/optimization.rs
@@ -510,15 +510,14 @@ impl BVH {
 }
 
 #[cfg(test)]
-pub mod tests {
-    use aabb::{Bounded, AABB};
+mod tests {
+    use aabb::Bounded;
     use bounding_hierarchy::BHShape;
     use bvh::{BVHNode, BVH};
     use nalgebra::Point3;
     use std::collections::HashSet;
     use testbase::{
-        build_some_bh, create_n_cubes, default_bounds, intersect_bh, load_sponza_scene,
-        randomly_transform_scene, Triangle, UnitBox,
+        build_some_bh, create_n_cubes, default_bounds, randomly_transform_scene, UnitBox,
     };
     use EPSILON;
 
@@ -714,26 +713,18 @@ pub mod tests {
         assert_eq!(nodes[5].parent(), 1);
         assert_eq!(nodes[6].parent(), 2);
 
-        assert!(
-            nodes[1]
-                .child_l_aabb()
-                .relative_eq(&shapes[2].aabb(), EPSILON)
-        );
-        assert!(
-            nodes[1]
-                .child_r_aabb()
-                .relative_eq(&shapes[1].aabb(), EPSILON)
-        );
-        assert!(
-            nodes[2]
-                .child_l_aabb()
-                .relative_eq(&shapes[0].aabb(), EPSILON)
-        );
-        assert!(
-            nodes[2]
-                .child_r_aabb()
-                .relative_eq(&shapes[3].aabb(), EPSILON)
-        );
+        assert!(nodes[1]
+            .child_l_aabb()
+            .relative_eq(&shapes[2].aabb(), EPSILON));
+        assert!(nodes[1]
+            .child_r_aabb()
+            .relative_eq(&shapes[1].aabb(), EPSILON));
+        assert!(nodes[2]
+            .child_l_aabb()
+            .relative_eq(&shapes[0].aabb(), EPSILON));
+        assert!(nodes[2]
+            .child_r_aabb()
+            .relative_eq(&shapes[3].aabb(), EPSILON));
     }
 
     #[test]
@@ -764,26 +755,18 @@ pub mod tests {
         assert_eq!(nodes[5].parent(), 0);
         assert_eq!(nodes[6].parent(), 2);
 
-        assert!(
-            nodes[0]
-                .child_l_aabb()
-                .relative_eq(&shapes[2].aabb(), EPSILON)
-        );
-        assert!(
-            nodes[2]
-                .child_r_aabb()
-                .relative_eq(&shapes[3].aabb(), EPSILON)
-        );
-        assert!(
-            nodes[1]
-                .child_l_aabb()
-                .relative_eq(&shapes[0].aabb(), EPSILON)
-        );
-        assert!(
-            nodes[1]
-                .child_r_aabb()
-                .relative_eq(&shapes[1].aabb(), EPSILON)
-        );
+        assert!(nodes[0]
+            .child_l_aabb()
+            .relative_eq(&shapes[2].aabb(), EPSILON));
+        assert!(nodes[2]
+            .child_r_aabb()
+            .relative_eq(&shapes[3].aabb(), EPSILON));
+        assert!(nodes[1]
+            .child_l_aabb()
+            .relative_eq(&shapes[0].aabb(), EPSILON));
+        assert!(nodes[1]
+            .child_r_aabb()
+            .relative_eq(&shapes[1].aabb(), EPSILON));
     }
 
     #[test]
@@ -813,26 +796,18 @@ pub mod tests {
         assert_eq!(nodes[5].parent(), 1);
         assert_eq!(nodes[6].parent(), 2);
 
-        assert!(
-            nodes[1]
-                .child_l_aabb()
-                .relative_eq(&shapes[2].aabb(), EPSILON)
-        );
-        assert!(
-            nodes[1]
-                .child_r_aabb()
-                .relative_eq(&shapes[1].aabb(), EPSILON)
-        );
-        assert!(
-            nodes[2]
-                .child_l_aabb()
-                .relative_eq(&shapes[0].aabb(), EPSILON)
-        );
-        assert!(
-            nodes[2]
-                .child_r_aabb()
-                .relative_eq(&shapes[3].aabb(), EPSILON)
-        );
+        assert!(nodes[1]
+            .child_l_aabb()
+            .relative_eq(&shapes[2].aabb(), EPSILON));
+        assert!(nodes[1]
+            .child_r_aabb()
+            .relative_eq(&shapes[1].aabb(), EPSILON));
+        assert!(nodes[2]
+            .child_l_aabb()
+            .relative_eq(&shapes[0].aabb(), EPSILON));
+        assert!(nodes[2]
+            .child_r_aabb()
+            .relative_eq(&shapes[3].aabb(), EPSILON));
     }
 
     #[test]
@@ -862,26 +837,18 @@ pub mod tests {
         assert_eq!(nodes[5].parent(), 0);
         assert_eq!(nodes[6].parent(), 2);
 
-        assert!(
-            nodes[0]
-                .child_l_aabb()
-                .relative_eq(&shapes[2].aabb(), EPSILON)
-        );
-        assert!(
-            nodes[2]
-                .child_r_aabb()
-                .relative_eq(&shapes[3].aabb(), EPSILON)
-        );
-        assert!(
-            nodes[1]
-                .child_l_aabb()
-                .relative_eq(&shapes[0].aabb(), EPSILON)
-        );
-        assert!(
-            nodes[1]
-                .child_r_aabb()
-                .relative_eq(&shapes[1].aabb(), EPSILON)
-        );
+        assert!(nodes[0]
+            .child_l_aabb()
+            .relative_eq(&shapes[2].aabb(), EPSILON));
+        assert!(nodes[2]
+            .child_r_aabb()
+            .relative_eq(&shapes[3].aabb(), EPSILON));
+        assert!(nodes[1]
+            .child_l_aabb()
+            .relative_eq(&shapes[0].aabb(), EPSILON));
+        assert!(nodes[1]
+            .child_r_aabb()
+            .relative_eq(&shapes[1].aabb(), EPSILON));
     }
 
     #[test]
@@ -917,36 +884,26 @@ pub mod tests {
         assert_eq!(nodes[5].parent(), 0);
         assert_eq!(nodes[6].parent(), 2);
 
-        assert!(
-            nodes[0]
-                .child_l_aabb()
-                .relative_eq(&shapes[2].aabb(), EPSILON)
-        );
+        assert!(nodes[0]
+            .child_l_aabb()
+            .relative_eq(&shapes[2].aabb(), EPSILON));
         let right_subtree_aabb = &shapes[0]
             .aabb()
             .join(&shapes[1].aabb())
             .join(&shapes[3].aabb());
-        assert!(
-            nodes[0]
-                .child_r_aabb()
-                .relative_eq(&right_subtree_aabb, EPSILON)
-        );
+        assert!(nodes[0]
+            .child_r_aabb()
+            .relative_eq(&right_subtree_aabb, EPSILON));
 
-        assert!(
-            nodes[2]
-                .child_r_aabb()
-                .relative_eq(&shapes[3].aabb(), EPSILON)
-        );
-        assert!(
-            nodes[1]
-                .child_l_aabb()
-                .relative_eq(&shapes[0].aabb(), EPSILON)
-        );
-        assert!(
-            nodes[1]
-                .child_r_aabb()
-                .relative_eq(&shapes[1].aabb(), EPSILON)
-        );
+        assert!(nodes[2]
+            .child_r_aabb()
+            .relative_eq(&shapes[3].aabb(), EPSILON));
+        assert!(nodes[1]
+            .child_l_aabb()
+            .relative_eq(&shapes[0].aabb(), EPSILON));
+        assert!(nodes[1]
+            .child_r_aabb()
+            .relative_eq(&shapes[1].aabb(), EPSILON));
     }
 
     #[test]
@@ -973,6 +930,16 @@ pub mod tests {
         bvh.assert_consistent(&triangles);
         bvh.assert_tight(&triangles);
     }
+}
+
+#[cfg(all(feature = "nightly", test))]
+mod bench {
+    use aabb::AABB;
+    use bvh::BVH;
+    use testbase::{
+        create_n_cubes, default_bounds, intersect_bh, load_sponza_scene, randomly_transform_scene,
+        Triangle,
+    };
 
     #[bench]
     /// Benchmark randomizing 50% of the shapes in a `BVH`.

--- a/src/bvh/optimization.rs
+++ b/src/bvh/optimization.rs
@@ -932,7 +932,7 @@ mod tests {
     }
 }
 
-#[cfg(all(feature = "nightly", test))]
+#[cfg(all(feature = "bench", test))]
 mod bench {
     use aabb::AABB;
     use bvh::BVH;

--- a/src/flat_bvh.rs
+++ b/src/flat_bvh.rs
@@ -427,14 +427,8 @@ impl BoundingHierarchy for FlatBVH {
 
 #[cfg(test)]
 mod tests {
-    use bvh::BVH;
     use flat_bvh::FlatBVH;
-
-    use testbase::{
-        build_1200_triangles_bh, build_120k_triangles_bh, build_12k_triangles_bh, build_some_bh,
-        create_n_cubes, default_bounds, intersect_1200_triangles_bh, intersect_120k_triangles_bh,
-        intersect_12k_triangles_bh, traverse_some_bh,
-    };
+    use testbase::{build_some_bh, traverse_some_bh};
 
     #[test]
     /// Tests whether the building procedure succeeds in not failing.
@@ -448,6 +442,18 @@ mod tests {
     fn test_traverse_flat_bvh() {
         traverse_some_bh::<FlatBVH>();
     }
+}
+
+#[cfg(all(feature = "nightly", test))]
+mod bench {
+    use bvh::BVH;
+    use flat_bvh::FlatBVH;
+
+    use testbase::{
+        build_1200_triangles_bh, build_120k_triangles_bh, build_12k_triangles_bh, create_n_cubes,
+        default_bounds, intersect_1200_triangles_bh, intersect_120k_triangles_bh,
+        intersect_12k_triangles_bh,
+    };
 
     #[bench]
     /// Benchmark the flattening of a BVH with 120,000 triangles.
@@ -460,7 +466,6 @@ mod tests {
             bvh.flatten();
         });
     }
-
     #[bench]
     /// Benchmark the construction of a `FlatBVH` with 1,200 triangles.
     fn bench_build_1200_triangles_flat_bvh(mut b: &mut ::test::Bencher) {

--- a/src/flat_bvh.rs
+++ b/src/flat_bvh.rs
@@ -444,7 +444,7 @@ mod tests {
     }
 }
 
-#[cfg(all(feature = "nightly", test))]
+#[cfg(all(feature = "bench", test))]
 mod bench {
     use bvh::BVH;
     use flat_bvh::FlatBVH;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@
 //!
 
 #![deny(missing_docs)]
-#![feature(test)]
+#![cfg_attr(feature = "nightly", feature(test))]
 
 #[macro_use]
 extern crate approx;
@@ -77,7 +77,7 @@ extern crate approx;
 extern crate log;
 #[cfg(test)]
 extern crate obj;
-#[cfg(test)]
+#[cfg(all(feature = "nightly", test))]
 extern crate test;
 #[cfg(test)]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@
 //!
 
 #![deny(missing_docs)]
-#![cfg_attr(feature = "nightly", feature(test))]
+#![cfg_attr(feature = "bench", feature(test))]
 
 #[macro_use]
 extern crate approx;
@@ -77,7 +77,7 @@ extern crate approx;
 extern crate log;
 #[cfg(test)]
 extern crate obj;
-#[cfg(all(feature = "nightly", test))]
+#[cfg(all(feature = "bench", test))]
 extern crate test;
 #[cfg(test)]
 #[macro_use]

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -465,7 +465,7 @@ mod tests {
     }
 }
 
-#[cfg(all(feature = "nightly", test))]
+#[cfg(all(feature = "bench", test))]
 mod bench {
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -45,11 +45,7 @@ impl Intersection {
     /// Constructs an `Intersection`. `distance` should be set to positive infinity,
     /// if the intersection does not occur.
     pub fn new(distance: f32, u: f32, v: f32) -> Intersection {
-        Intersection {
-            distance,
-            u,
-            v,
-        }
+        Intersection { distance, u, v }
     }
 }
 
@@ -313,13 +309,11 @@ mod tests {
     use std::cmp;
     use std::f32::INFINITY;
 
-    use rand::{Rng, SeedableRng, StdRng};
-
     use aabb::AABB;
     use ray::Ray;
     use EPSILON;
 
-    use testbase::{tuple_to_point, tuple_to_vector, TupleVec};
+    use testbase::{tuple_to_point, TupleVec};
 
     /// Generates a random `Ray` which points at at a random `AABB`.
     fn gen_ray_to_aabb(data: (TupleVec, TupleVec, TupleVec)) -> (Ray, AABB) {
@@ -339,7 +333,7 @@ mod tests {
 
     /// Test whether a `Ray` which points at the center of an `AABB` intersects it.
     /// Uses the optimized algorithm.
-    quickcheck!{
+    quickcheck! {
         fn test_ray_points_at_aabb_center(data: (TupleVec, TupleVec, TupleVec)) -> bool {
             let (ray, aabb) = gen_ray_to_aabb(data);
             ray.intersects_aabb(&aabb)
@@ -348,7 +342,7 @@ mod tests {
 
     /// Test whether a `Ray` which points at the center of an `AABB` intersects it.
     /// Uses the naive algorithm.
-    quickcheck!{
+    quickcheck! {
         fn test_ray_points_at_aabb_center_naive(data: (TupleVec, TupleVec, TupleVec)) -> bool {
             let (ray, aabb) = gen_ray_to_aabb(data);
             ray.intersects_aabb_naive(&aabb)
@@ -357,7 +351,7 @@ mod tests {
 
     /// Test whether a `Ray` which points at the center of an `AABB` intersects it.
     /// Uses the branchless algorithm.
-    quickcheck!{
+    quickcheck! {
         fn test_ray_points_at_aabb_center_branchless(data: (TupleVec, TupleVec, TupleVec)) -> bool {
             let (ray, aabb) = gen_ray_to_aabb(data);
             ray.intersects_aabb_branchless(&aabb)
@@ -367,7 +361,7 @@ mod tests {
     /// Test whether a `Ray` which points away from the center of an `AABB`
     /// does not intersect it, unless its origin is inside the `AABB`.
     /// Uses the optimized algorithm.
-    quickcheck!{
+    quickcheck! {
         fn test_ray_points_from_aabb_center(data: (TupleVec, TupleVec, TupleVec)) -> bool {
             let (mut ray, aabb) = gen_ray_to_aabb(data);
 
@@ -381,7 +375,7 @@ mod tests {
     /// Test whether a `Ray` which points away from the center of an `AABB`
     /// does not intersect it, unless its origin is inside the `AABB`.
     /// Uses the naive algorithm.
-    quickcheck!{
+    quickcheck! {
         fn test_ray_points_from_aabb_center_naive(data: (TupleVec, TupleVec, TupleVec)) -> bool {
             let (mut ray, aabb) = gen_ray_to_aabb(data);
 
@@ -395,7 +389,7 @@ mod tests {
     /// Test whether a `Ray` which points away from the center of an `AABB`
     /// does not intersect it, unless its origin is inside the `AABB`.
     /// Uses the branchless algorithm.
-    quickcheck!{
+    quickcheck! {
         fn test_ray_points_from_aabb_center_branchless(data: (TupleVec, TupleVec, TupleVec))
                                                        -> bool {
             let (mut ray, aabb) = gen_ray_to_aabb(data);
@@ -408,7 +402,7 @@ mod tests {
 
     /// Test whether a `Ray` which points at the center of a triangle
     /// intersects it, unless it sees the back face, which is culled.
-    quickcheck!{
+    quickcheck! {
         fn test_ray_hits_triangle(a: TupleVec,
                                   b: TupleVec,
                                   c: TupleVec,
@@ -469,6 +463,17 @@ mod tests {
             }
         }
     }
+}
+
+#[cfg(all(feature = "nightly", test))]
+mod bench {
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+
+    use aabb::AABB;
+    use ray::Ray;
+
+    use testbase::{tuple_to_point, tuple_to_vector, TupleVec};
 
     /// Generates some random deterministic `Ray`/`AABB` pairs.
     fn gen_random_ray_aabb(rng: &mut StdRng) -> (Ray, AABB) {

--- a/src/testbase.rs
+++ b/src/testbase.rs
@@ -3,14 +3,14 @@
 
 use std::collections::HashSet;
 use std::f32;
-use std::fs::File;
-use std::io::BufReader;
 use std::mem::transmute;
 
 use nalgebra::{Point3, Vector3};
 use obj::raw::object::Polygon;
 use obj::*;
-use rand::{Rng, SeedableRng, StdRng};
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
+use rand::SeedableRng;
 
 use aabb::{Bounded, AABB};
 use bounding_hierarchy::{BHShape, BoundingHierarchy};
@@ -354,7 +354,11 @@ pub fn create_n_cubes(n: usize, bounds: &AABB) -> Vec<Triangle> {
 }
 
 /// Loads the sponza model.
+#[cfg(feature = "nightly")]
 pub fn load_sponza_scene() -> (Vec<Triangle>, AABB) {
+    use std::fs::File;
+    use std::io::BufReader;
+
     let file_input =
         BufReader::new(File::open("media/sponza.obj").expect("Failed to open .obj file."));
     let sponza_obj: Obj<Triangle> = load_obj(file_input).expect("Failed to decode .obj file data.");
@@ -386,7 +390,7 @@ pub fn randomly_transform_scene(
         seed_array[i] = bytes[i % 8];
     }
     let mut rng: StdRng = SeedableRng::from_seed(seed_array);
-    rng.shuffle(&mut indices);
+    indices.shuffle(&mut rng);
     indices.truncate(amount);
 
     let max_offset = if let Some(value) = max_offset_option {
@@ -422,6 +426,7 @@ pub fn randomly_transform_scene(
 /// Creates a `Ray` from the random `seed`. Mutates the `seed`.
 /// The Ray origin will be inside the `bounds` and point to some other point inside this
 /// `bounds`.
+#[cfg(feature = "nightly")]
 pub fn create_ray(seed: &mut u64, bounds: &AABB) -> Ray {
     let origin = next_point3(seed, bounds);
     let direction = next_point3(seed, bounds).coords;
@@ -429,6 +434,7 @@ pub fn create_ray(seed: &mut u64, bounds: &AABB) -> Ray {
 }
 
 /// Benchmark the construction of a `BoundingHierarchy` with `n` triangles.
+#[cfg(feature = "nightly")]
 fn build_n_triangles_bh<T: BoundingHierarchy>(n: usize, b: &mut ::test::Bencher) {
     let bounds = default_bounds();
     let mut triangles = create_n_cubes(n, &bounds);
@@ -438,21 +444,25 @@ fn build_n_triangles_bh<T: BoundingHierarchy>(n: usize, b: &mut ::test::Bencher)
 }
 
 /// Benchmark the construction of a `BoundingHierarchy` with 1,200 triangles.
+#[cfg(feature = "nightly")]
 pub fn build_1200_triangles_bh<T: BoundingHierarchy>(b: &mut ::test::Bencher) {
     build_n_triangles_bh::<T>(100, b);
 }
 
 /// Benchmark the construction of a `BoundingHierarchy` with 12,000 triangles.
+#[cfg(feature = "nightly")]
 pub fn build_12k_triangles_bh<T: BoundingHierarchy>(b: &mut ::test::Bencher) {
     build_n_triangles_bh::<T>(1_000, b);
 }
 
 /// Benchmark the construction of a `BoundingHierarchy` with 120,000 triangles.
+#[cfg(feature = "nightly")]
 pub fn build_120k_triangles_bh<T: BoundingHierarchy>(b: &mut ::test::Bencher) {
     build_n_triangles_bh::<T>(10_000, b);
 }
 
 /// Benchmark intersecting the `triangles` list without acceleration structures.
+#[cfg(feature = "nightly")]
 pub fn intersect_list(triangles: &[Triangle], bounds: &AABB, b: &mut ::test::Bencher) {
     let mut seed = 0;
     b.iter(|| {
@@ -465,6 +475,7 @@ pub fn intersect_list(triangles: &[Triangle], bounds: &AABB, b: &mut ::test::Ben
     });
 }
 
+#[cfg(feature = "nightly")]
 #[bench]
 /// Benchmark intersecting 120,000 triangles directly.
 fn bench_intersect_120k_triangles_list(b: &mut ::test::Bencher) {
@@ -473,6 +484,7 @@ fn bench_intersect_120k_triangles_list(b: &mut ::test::Bencher) {
     intersect_list(&triangles, &bounds, b);
 }
 
+#[cfg(feature = "nightly")]
 #[bench]
 /// Benchmark intersecting Sponza.
 fn bench_intersect_sponza_list(b: &mut ::test::Bencher) {
@@ -482,6 +494,7 @@ fn bench_intersect_sponza_list(b: &mut ::test::Bencher) {
 
 /// Benchmark intersecting the `triangles` list with `AABB` checks, but without acceleration
 /// structures.
+#[cfg(feature = "nightly")]
 pub fn intersect_list_aabb(triangles: &[Triangle], bounds: &AABB, b: &mut ::test::Bencher) {
     let mut seed = 0;
     b.iter(|| {
@@ -497,6 +510,7 @@ pub fn intersect_list_aabb(triangles: &[Triangle], bounds: &AABB, b: &mut ::test
     });
 }
 
+#[cfg(feature = "nightly")]
 #[bench]
 /// Benchmark intersecting 120,000 triangles with preceeding `AABB` tests.
 fn bench_intersect_120k_triangles_list_aabb(b: &mut ::test::Bencher) {
@@ -505,6 +519,7 @@ fn bench_intersect_120k_triangles_list_aabb(b: &mut ::test::Bencher) {
     intersect_list_aabb(&triangles, &bounds, b);
 }
 
+#[cfg(feature = "nightly")]
 #[bench]
 /// Benchmark intersecting 120,000 triangles with preceeding `AABB` tests.
 fn bench_intersect_sponza_list_aabb(b: &mut ::test::Bencher) {
@@ -512,6 +527,7 @@ fn bench_intersect_sponza_list_aabb(b: &mut ::test::Bencher) {
     intersect_list_aabb(&triangles, &bounds, b);
 }
 
+#[cfg(feature = "nightly")]
 pub fn intersect_bh<T: BoundingHierarchy>(
     bh: &T,
     triangles: &[Triangle],
@@ -533,6 +549,7 @@ pub fn intersect_bh<T: BoundingHierarchy>(
 }
 
 /// Benchmark the traversal of a `BoundingHierarchy` with `n` triangles.
+#[cfg(feature = "nightly")]
 pub fn intersect_n_triangles<T: BoundingHierarchy>(n: usize, b: &mut ::test::Bencher) {
     let bounds = default_bounds();
     let mut triangles = create_n_cubes(n, &bounds);
@@ -541,16 +558,19 @@ pub fn intersect_n_triangles<T: BoundingHierarchy>(n: usize, b: &mut ::test::Ben
 }
 
 /// Benchmark the traversal of a `BoundingHierarchy` with 1,200 triangles.
+#[cfg(feature = "nightly")]
 pub fn intersect_1200_triangles_bh<T: BoundingHierarchy>(b: &mut ::test::Bencher) {
     intersect_n_triangles::<T>(100, b);
 }
 
 /// Benchmark the traversal of a `BoundingHierarchy` with 12,000 triangles.
+#[cfg(feature = "nightly")]
 pub fn intersect_12k_triangles_bh<T: BoundingHierarchy>(b: &mut ::test::Bencher) {
     intersect_n_triangles::<T>(1_000, b);
 }
 
 /// Benchmark the traversal of a `BoundingHierarchy` with 120,000 triangles.
+#[cfg(feature = "nightly")]
 pub fn intersect_120k_triangles_bh<T: BoundingHierarchy>(b: &mut ::test::Bencher) {
     intersect_n_triangles::<T>(10_000, b);
 }

--- a/src/testbase.rs
+++ b/src/testbase.rs
@@ -354,7 +354,7 @@ pub fn create_n_cubes(n: usize, bounds: &AABB) -> Vec<Triangle> {
 }
 
 /// Loads the sponza model.
-#[cfg(feature = "nightly")]
+#[cfg(feature = "bench")]
 pub fn load_sponza_scene() -> (Vec<Triangle>, AABB) {
     use std::fs::File;
     use std::io::BufReader;
@@ -426,7 +426,7 @@ pub fn randomly_transform_scene(
 /// Creates a `Ray` from the random `seed`. Mutates the `seed`.
 /// The Ray origin will be inside the `bounds` and point to some other point inside this
 /// `bounds`.
-#[cfg(feature = "nightly")]
+#[cfg(feature = "bench")]
 pub fn create_ray(seed: &mut u64, bounds: &AABB) -> Ray {
     let origin = next_point3(seed, bounds);
     let direction = next_point3(seed, bounds).coords;
@@ -434,7 +434,7 @@ pub fn create_ray(seed: &mut u64, bounds: &AABB) -> Ray {
 }
 
 /// Benchmark the construction of a `BoundingHierarchy` with `n` triangles.
-#[cfg(feature = "nightly")]
+#[cfg(feature = "bench")]
 fn build_n_triangles_bh<T: BoundingHierarchy>(n: usize, b: &mut ::test::Bencher) {
     let bounds = default_bounds();
     let mut triangles = create_n_cubes(n, &bounds);
@@ -444,25 +444,25 @@ fn build_n_triangles_bh<T: BoundingHierarchy>(n: usize, b: &mut ::test::Bencher)
 }
 
 /// Benchmark the construction of a `BoundingHierarchy` with 1,200 triangles.
-#[cfg(feature = "nightly")]
+#[cfg(feature = "bench")]
 pub fn build_1200_triangles_bh<T: BoundingHierarchy>(b: &mut ::test::Bencher) {
     build_n_triangles_bh::<T>(100, b);
 }
 
 /// Benchmark the construction of a `BoundingHierarchy` with 12,000 triangles.
-#[cfg(feature = "nightly")]
+#[cfg(feature = "bench")]
 pub fn build_12k_triangles_bh<T: BoundingHierarchy>(b: &mut ::test::Bencher) {
     build_n_triangles_bh::<T>(1_000, b);
 }
 
 /// Benchmark the construction of a `BoundingHierarchy` with 120,000 triangles.
-#[cfg(feature = "nightly")]
+#[cfg(feature = "bench")]
 pub fn build_120k_triangles_bh<T: BoundingHierarchy>(b: &mut ::test::Bencher) {
     build_n_triangles_bh::<T>(10_000, b);
 }
 
 /// Benchmark intersecting the `triangles` list without acceleration structures.
-#[cfg(feature = "nightly")]
+#[cfg(feature = "bench")]
 pub fn intersect_list(triangles: &[Triangle], bounds: &AABB, b: &mut ::test::Bencher) {
     let mut seed = 0;
     b.iter(|| {
@@ -475,7 +475,7 @@ pub fn intersect_list(triangles: &[Triangle], bounds: &AABB, b: &mut ::test::Ben
     });
 }
 
-#[cfg(feature = "nightly")]
+#[cfg(feature = "bench")]
 #[bench]
 /// Benchmark intersecting 120,000 triangles directly.
 fn bench_intersect_120k_triangles_list(b: &mut ::test::Bencher) {
@@ -484,7 +484,7 @@ fn bench_intersect_120k_triangles_list(b: &mut ::test::Bencher) {
     intersect_list(&triangles, &bounds, b);
 }
 
-#[cfg(feature = "nightly")]
+#[cfg(feature = "bench")]
 #[bench]
 /// Benchmark intersecting Sponza.
 fn bench_intersect_sponza_list(b: &mut ::test::Bencher) {
@@ -494,7 +494,7 @@ fn bench_intersect_sponza_list(b: &mut ::test::Bencher) {
 
 /// Benchmark intersecting the `triangles` list with `AABB` checks, but without acceleration
 /// structures.
-#[cfg(feature = "nightly")]
+#[cfg(feature = "bench")]
 pub fn intersect_list_aabb(triangles: &[Triangle], bounds: &AABB, b: &mut ::test::Bencher) {
     let mut seed = 0;
     b.iter(|| {
@@ -510,7 +510,7 @@ pub fn intersect_list_aabb(triangles: &[Triangle], bounds: &AABB, b: &mut ::test
     });
 }
 
-#[cfg(feature = "nightly")]
+#[cfg(feature = "bench")]
 #[bench]
 /// Benchmark intersecting 120,000 triangles with preceeding `AABB` tests.
 fn bench_intersect_120k_triangles_list_aabb(b: &mut ::test::Bencher) {
@@ -519,7 +519,7 @@ fn bench_intersect_120k_triangles_list_aabb(b: &mut ::test::Bencher) {
     intersect_list_aabb(&triangles, &bounds, b);
 }
 
-#[cfg(feature = "nightly")]
+#[cfg(feature = "bench")]
 #[bench]
 /// Benchmark intersecting 120,000 triangles with preceeding `AABB` tests.
 fn bench_intersect_sponza_list_aabb(b: &mut ::test::Bencher) {
@@ -527,7 +527,7 @@ fn bench_intersect_sponza_list_aabb(b: &mut ::test::Bencher) {
     intersect_list_aabb(&triangles, &bounds, b);
 }
 
-#[cfg(feature = "nightly")]
+#[cfg(feature = "bench")]
 pub fn intersect_bh<T: BoundingHierarchy>(
     bh: &T,
     triangles: &[Triangle],
@@ -549,7 +549,7 @@ pub fn intersect_bh<T: BoundingHierarchy>(
 }
 
 /// Benchmark the traversal of a `BoundingHierarchy` with `n` triangles.
-#[cfg(feature = "nightly")]
+#[cfg(feature = "bench")]
 pub fn intersect_n_triangles<T: BoundingHierarchy>(n: usize, b: &mut ::test::Bencher) {
     let bounds = default_bounds();
     let mut triangles = create_n_cubes(n, &bounds);
@@ -558,19 +558,19 @@ pub fn intersect_n_triangles<T: BoundingHierarchy>(n: usize, b: &mut ::test::Ben
 }
 
 /// Benchmark the traversal of a `BoundingHierarchy` with 1,200 triangles.
-#[cfg(feature = "nightly")]
+#[cfg(feature = "bench")]
 pub fn intersect_1200_triangles_bh<T: BoundingHierarchy>(b: &mut ::test::Bencher) {
     intersect_n_triangles::<T>(100, b);
 }
 
 /// Benchmark the traversal of a `BoundingHierarchy` with 12,000 triangles.
-#[cfg(feature = "nightly")]
+#[cfg(feature = "bench")]
 pub fn intersect_12k_triangles_bh<T: BoundingHierarchy>(b: &mut ::test::Bencher) {
     intersect_n_triangles::<T>(1_000, b);
 }
 
 /// Benchmark the traversal of a `BoundingHierarchy` with 120,000 triangles.
-#[cfg(feature = "nightly")]
+#[cfg(feature = "bench")]
 pub fn intersect_120k_triangles_bh<T: BoundingHierarchy>(b: &mut ::test::Bencher) {
     intersect_n_triangles::<T>(10_000, b);
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -58,7 +58,7 @@ pub fn joint_aabb_of_shapes<Shape: BHShape>(indices: &[usize], shapes: &[Shape])
 }
 
 #[cfg(test)]
-pub mod tests {
+mod tests {
     use utils::concatenate_vectors;
 
     #[test]


### PR DESCRIPTION
Compiling on stable complains due to `#![feature(test)]`, this appears to be the only nightly feature used and its limited to the benchmark suite. Put this behind a "nightly" feature gate to enable usage on stable.

Perhaps "bench" or something similar is a more appropriate name for the feature given it's scope, and perhaps this should not be on by default (set to default now to match current behavior).