### PR TITLE
Update to 2018 edition

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,1 @@
 error_on_line_overflow = false
-closure_block_indent_threshold = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "bvh"
 description = "A fast BVH using SAH"
 version = "0.2.4"
+edition = "2018"
 authors = [
     "Sven-Hendrik Haase <svenstaro@gmail.com>",
     "Alexander Dmitriev <alexander.dmitriev2580@gmail.com>"

--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -4,9 +4,10 @@ use std::f32;
 use std::fmt;
 use std::ops::Index;
 
+use approx::relative_eq;
 use nalgebra::{Point3, Vector3};
 
-use axis::Axis;
+use crate::axis::Axis;
 
 /// AABB struct.
 #[derive(Debug, Copy, Clone)]
@@ -648,14 +649,15 @@ impl Bounded for Point3<f32> {
 
 #[cfg(test)]
 mod tests {
-    use aabb::{Bounded, AABB};
-    use nalgebra::{Point3, Vector3};
-    use EPSILON;
+    use crate::aabb::{Bounded, AABB};
+    use crate::testbase::{tuple_to_point, tuple_to_vector, TupleVec};
+    use crate::EPSILON;
 
-    use testbase::{tuple_to_point, tuple_to_vector, TupleVec};
+    use nalgebra::{Point3, Vector3};
+    use quickcheck::quickcheck;
 
     /// Test whether an empty `AABB` does not contains anything.
-    quickcheck!{
+    quickcheck! {
         fn test_empty_contains_nothing(tpl: TupleVec) -> bool {
             // Define a random Point
             let p = tuple_to_point(&tpl);
@@ -669,7 +671,7 @@ mod tests {
     }
 
     /// Test whether a default `AABB` is empty.
-    quickcheck!{
+    quickcheck! {
         fn test_default_is_empty(tpl: TupleVec) -> bool {
             // Define a random Point
             let p = tuple_to_point(&tpl);
@@ -683,7 +685,7 @@ mod tests {
     }
 
     /// Test whether an `AABB` always contains its center.
-    quickcheck!{
+    quickcheck! {
         fn test_aabb_contains_center(a: TupleVec, b: TupleVec) -> bool {
             // Define two points which will be the corners of the `AABB`
             let p1 = tuple_to_point(&a);
@@ -698,7 +700,7 @@ mod tests {
     }
 
     /// Test whether the joint of two point-sets contains all the points.
-    quickcheck!{
+    quickcheck! {
         fn test_join_two_aabbs(a: (TupleVec, TupleVec, TupleVec, TupleVec, TupleVec),
                                b: (TupleVec, TupleVec, TupleVec, TupleVec, TupleVec))
                                -> bool {
@@ -734,7 +736,7 @@ mod tests {
     }
 
     /// Test whether some points relative to the center of an AABB are classified correctly.
-    quickcheck!{
+    quickcheck! {
         fn test_points_relative_to_center_and_size(a: TupleVec, b: TupleVec) -> bool {
             // Generate some nonempty AABB
             let aabb = AABB::empty()
@@ -764,7 +766,7 @@ mod tests {
     }
 
     /// Test whether the surface of a nonempty AABB is always positive.
-    quickcheck!{
+    quickcheck! {
         fn test_surface_always_positive(a: TupleVec, b: TupleVec) -> bool {
             let aabb = AABB::empty()
                 .grow(&tuple_to_point(&a))
@@ -774,7 +776,7 @@ mod tests {
     }
 
     /// Compute and compare the surface area of an AABB by hand.
-    quickcheck!{
+    quickcheck! {
         fn test_surface_area_cube(pos: TupleVec, size: f32) -> bool {
             // Generate some non-empty AABB
             let pos = tuple_to_point(&pos);
@@ -789,7 +791,7 @@ mod tests {
     }
 
     /// Test whether the volume of a nonempty AABB is always positive.
-    quickcheck!{
+    quickcheck! {
         fn test_volume_always_positive(a: TupleVec, b: TupleVec) -> bool {
             let aabb = AABB::empty()
                 .grow(&tuple_to_point(&a))
@@ -799,7 +801,7 @@ mod tests {
     }
 
     /// Compute and compare the volume of an AABB by hand.
-    quickcheck!{
+    quickcheck! {
         fn test_volume_by_hand(pos: TupleVec, size: TupleVec) -> bool {
             // Generate some non-empty AABB
             let pos = tuple_to_point(&pos);
@@ -814,7 +816,7 @@ mod tests {
     }
 
     /// Test whether generating an `AABB` from the min and max bounds yields the same `AABB`.
-    quickcheck!{
+    quickcheck! {
         fn test_create_aabb_from_indexable(a: TupleVec, b: TupleVec, p: TupleVec) -> bool {
             // Create a random point
             let point = tuple_to_point(&p);

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -131,10 +131,11 @@ impl IndexMut<Axis> for MyType<Vector3<f32>> {
 
 #[cfg(test)]
 mod test {
-    use axis::Axis;
+    use crate::axis::Axis;
+    use quickcheck::quickcheck;
 
     /// Test whether accessing arrays by index is the same as accessing them by `Axis`.
-    quickcheck!{
+    quickcheck! {
         fn test_index_by_axis(tpl: (f32, f32, f32)) -> bool {
             let a = [tpl.0, tpl.1, tpl.2];
 
@@ -143,7 +144,7 @@ mod test {
     }
 
     /// Test whether arrays can be mutably set, by indexing via `Axis`.
-    quickcheck!{
+    quickcheck! {
         fn test_set_by_axis(tpl: (f32, f32, f32)) -> bool {
             let mut a = [0.0, 0.0, 0.0];
 

--- a/src/bounding_hierarchy.rs
+++ b/src/bounding_hierarchy.rs
@@ -1,7 +1,7 @@
 //! This module defines the `BoundingHierarchy` trait.
 
-use aabb::Bounded;
-use ray::Ray;
+use crate::aabb::Bounded;
+use crate::ray::Ray;
 
 /// Describes a shape as referenced by a [`BoundingHierarchy`] leaf node.
 /// Knows the index of the node in the [`BoundingHierarchy`] it is in.
@@ -13,7 +13,7 @@ pub trait BHShape: Bounded {
     ///
     /// [`BoundingHierarchy`]: struct.BoundingHierarchy.html
     ///
-    fn set_bh_node_index(&mut self, usize);
+    fn set_bh_node_index(&mut self, _: usize);
 
     /// Gets the index of the referenced [`BoundingHierarchy`] node.
     ///

--- a/src/bvh/bvh.rs
+++ b/src/bvh/bvh.rs
@@ -4,14 +4,14 @@
 //! [`BVHNode`]: struct.BVHNode.html
 //!
 
-use aabb::{Bounded, AABB};
-use bounding_hierarchy::{BHShape, BoundingHierarchy};
+use crate::aabb::{Bounded, AABB};
+use crate::bounding_hierarchy::{BHShape, BoundingHierarchy};
+use crate::ray::Ray;
+use crate::utils::{concatenate_vectors, joint_aabb_of_shapes, Bucket};
+use crate::EPSILON;
 use nalgebra::Point3;
-use ray::Ray;
 use std::f32;
 use std::iter::repeat;
-use utils::{concatenate_vectors, joint_aabb_of_shapes, Bucket};
-use EPSILON;
 
 /// The [`BVHNode`] enum that describes a node in a [`BVH`].
 /// It's either a leaf node and references a shape (by holding its index)
@@ -701,8 +701,8 @@ impl BoundingHierarchy for BVH {
 
 #[cfg(test)]
 mod tests {
-    use bvh::BVH;
-    use testbase::{build_some_bh, traverse_some_bh};
+    use crate::bvh::BVH;
+    use crate::testbase::{build_some_bh, traverse_some_bh};
 
     #[test]
     /// Tests whether the building procedure succeeds in not failing.

--- a/src/bvh/optimization.rs
+++ b/src/bvh/optimization.rs
@@ -6,9 +6,11 @@
 //! [`BVH`]: struct.BVH.html
 //!
 
-use aabb::AABB;
-use bounding_hierarchy::BHShape;
-use bvh::*;
+use crate::aabb::AABB;
+use crate::bounding_hierarchy::BHShape;
+use crate::bvh::*;
+
+use log::info;
 use rand::{thread_rng, Rng};
 use std::collections::HashSet;
 
@@ -511,15 +513,15 @@ impl BVH {
 
 #[cfg(test)]
 mod tests {
-    use aabb::Bounded;
-    use bounding_hierarchy::BHShape;
-    use bvh::{BVHNode, BVH};
-    use nalgebra::Point3;
-    use std::collections::HashSet;
-    use testbase::{
+    use crate::aabb::Bounded;
+    use crate::bounding_hierarchy::BHShape;
+    use crate::bvh::{BVHNode, BVH};
+    use crate::testbase::{
         build_some_bh, create_n_cubes, default_bounds, randomly_transform_scene, UnitBox,
     };
-    use EPSILON;
+    use crate::EPSILON;
+    use nalgebra::Point3;
+    use std::collections::HashSet;
 
     #[test]
     /// Tests if `optimize` does not modify a fresh `BVH`.
@@ -934,9 +936,9 @@ mod tests {
 
 #[cfg(all(feature = "bench", test))]
 mod bench {
-    use aabb::AABB;
-    use bvh::BVH;
-    use testbase::{
+    use crate::aabb::AABB;
+    use crate::bvh::BVH;
+    use crate::testbase::{
         create_n_cubes, default_bounds, intersect_bh, load_sponza_scene, randomly_transform_scene,
         Triangle,
     };

--- a/src/flat_bvh.rs
+++ b/src/flat_bvh.rs
@@ -1,9 +1,9 @@
 //! This module exports methods to flatten the `BVH` and traverse it iteratively.
 
-use aabb::{Bounded, AABB};
-use bounding_hierarchy::{BHShape, BoundingHierarchy};
-use bvh::{BVHNode, BVH};
-use ray::Ray;
+use crate::aabb::{Bounded, AABB};
+use crate::bounding_hierarchy::{BHShape, BoundingHierarchy};
+use crate::bvh::{BVHNode, BVH};
+use crate::ray::Ray;
 
 /// A structure of a node of a flat [`BVH`]. The structure of the nodes allows for an
 /// iterative traversal approach without the necessity to maintain a stack or queue.
@@ -427,8 +427,8 @@ impl BoundingHierarchy for FlatBVH {
 
 #[cfg(test)]
 mod tests {
-    use flat_bvh::FlatBVH;
-    use testbase::{build_some_bh, traverse_some_bh};
+    use crate::flat_bvh::FlatBVH;
+    use crate::testbase::{build_some_bh, traverse_some_bh};
 
     #[test]
     /// Tests whether the building procedure succeeds in not failing.
@@ -446,10 +446,10 @@ mod tests {
 
 #[cfg(all(feature = "bench", test))]
 mod bench {
-    use bvh::BVH;
-    use flat_bvh::FlatBVH;
+    use crate::bvh::BVH;
+    use crate::flat_bvh::FlatBVH;
 
-    use testbase::{
+    use crate::testbase::{
         build_1200_triangles_bh, build_120k_triangles_bh, build_12k_triangles_bh, create_n_cubes,
         default_bounds, intersect_1200_triangles_bh, intersect_120k_triangles_bh,
         intersect_12k_triangles_bh,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,20 +71,10 @@
 #![deny(missing_docs)]
 #![cfg_attr(feature = "bench", feature(test))]
 
-#[macro_use]
-extern crate approx;
-#[macro_use]
-extern crate log;
-#[cfg(test)]
-extern crate obj;
 #[cfg(all(feature = "bench", test))]
 extern crate test;
-#[cfg(test)]
-#[macro_use]
-extern crate quickcheck;
 
-pub extern crate nalgebra;
-extern crate rand;
+pub use nalgebra;
 
 /// A minimal floating value used as a lower bound.
 /// TODO: replace by/add ULPS/relative float comparison methods.

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -1,10 +1,10 @@
 //! This module defines a Ray structure and intersection algorithms
 //! for axis aligned bounding boxes and triangles.
 
-use aabb::AABB;
+use crate::aabb::AABB;
+use crate::EPSILON;
 use nalgebra::{Point3, Vector3};
 use std::f32::INFINITY;
-use EPSILON;
 
 /// A struct which defines a ray and some of its cached values.
 #[derive(Debug)]
@@ -309,11 +309,12 @@ mod tests {
     use std::cmp;
     use std::f32::INFINITY;
 
-    use aabb::AABB;
-    use ray::Ray;
-    use EPSILON;
+    use crate::aabb::AABB;
+    use crate::ray::Ray;
+    use crate::testbase::{tuple_to_point, TupleVec};
+    use crate::EPSILON;
 
-    use testbase::{tuple_to_point, TupleVec};
+    use quickcheck::quickcheck;
 
     /// Generates a random `Ray` which points at at a random `AABB`.
     fn gen_ray_to_aabb(data: (TupleVec, TupleVec, TupleVec)) -> (Ray, AABB) {
@@ -470,10 +471,10 @@ mod bench {
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
 
-    use aabb::AABB;
-    use ray::Ray;
+    use crate::aabb::AABB;
+    use crate::ray::Ray;
 
-    use testbase::{tuple_to_point, tuple_to_vector, TupleVec};
+    use crate::testbase::{tuple_to_point, tuple_to_vector, TupleVec};
 
     /// Generates some random deterministic `Ray`/`AABB` pairs.
     fn gen_random_ray_aabb(rng: &mut StdRng) -> (Ray, AABB) {

--- a/src/testbase.rs
+++ b/src/testbase.rs
@@ -12,9 +12,9 @@ use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::SeedableRng;
 
-use aabb::{Bounded, AABB};
-use bounding_hierarchy::{BHShape, BoundingHierarchy};
-use ray::Ray;
+use crate::aabb::{Bounded, AABB};
+use crate::bounding_hierarchy::{BHShape, BoundingHierarchy};
+use crate::ray::Ray;
 
 /// A vector represented as a tuple
 pub type TupleVec = (f32, f32, f32);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 //! Utilities module.
 
-use aabb::AABB;
-use bounding_hierarchy::BHShape;
+use crate::aabb::AABB;
+use crate::bounding_hierarchy::BHShape;
 
 /// Concatenates the list of vectors into a single vector.
 /// Drains the elements from the source `vectors`.
@@ -59,7 +59,7 @@ pub fn joint_aabb_of_shapes<Shape: BHShape>(indices: &[usize], shapes: &[Shape])
 
 #[cfg(test)]
 mod tests {
-    use utils::concatenate_vectors;
+    use crate::utils::concatenate_vectors;
 
     #[test]
     /// Test if concatenating no `Vec`s yields an empty `Vec`.


### PR DESCRIPTION
Mostly result of `cargo fix --edition` plus some manual fixes of import paths/extern crate removals and a fresh `cargo fmt` with latest rustfmt.