### PR TITLE
[WIP] Add traversal queries based on points

### DIFF
--- a/src/bounding_hierarchy.rs
+++ b/src/bounding_hierarchy.rs
@@ -2,6 +2,7 @@
 
 use crate::aabb::Bounded;
 use crate::ray::Ray;
+use nalgebra::Point3;
 
 /// Describes a shape as referenced by a [`BoundingHierarchy`] leaf node.
 /// Knows the index of the node in the [`BoundingHierarchy`] it is in.
@@ -163,6 +164,73 @@ pub trait BoundingHierarchy {
     /// [`AABB`]: ../aabb/struct.AABB.html
     ///
     fn traverse<'a, Shape: BHShape>(&'a self, ray: &Ray, shapes: &'a [Shape]) -> Vec<&Shape>;
+
+    /// Traverses the [`BoundingHierarchy`].
+    /// Returns a subset of `shapes`, in which the [`AABB`]s of the elements contain `pt`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bvh::aabb::{AABB, Bounded};
+    /// use bvh::bounding_hierarchy::BoundingHierarchy;
+    /// use bvh::bvh::BVH;
+    /// use bvh::nalgebra::{Point3, Vector3};
+    /// use bvh::ray::Ray;
+    /// # use bvh::bounding_hierarchy::BHShape;
+    /// # pub struct UnitBox {
+    /// #     pub id: i32,
+    /// #     pub pos: Point3<f32>,
+    /// #     node_index: usize,
+    /// # }
+    /// #
+    /// # impl UnitBox {
+    /// #     pub fn new(id: i32, pos: Point3<f32>) -> UnitBox {
+    /// #         UnitBox {
+    /// #             id: id,
+    /// #             pos: pos,
+    /// #             node_index: 0,
+    /// #         }
+    /// #     }
+    /// # }
+    /// #
+    /// # impl Bounded for UnitBox {
+    /// #     fn aabb(&self) -> AABB {
+    /// #         let min = self.pos + Vector3::new(-0.5, -0.5, -0.5);
+    /// #         let max = self.pos + Vector3::new(0.5, 0.5, 0.5);
+    /// #         AABB::with_bounds(min, max)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl BHShape for UnitBox {
+    /// #     fn set_bh_node_index(&mut self, index: usize) {
+    /// #         self.node_index = index;
+    /// #     }
+    /// #
+    /// #     fn bh_node_index(&self) -> usize {
+    /// #         self.node_index
+    /// #     }
+    /// # }
+    /// #
+    /// # fn create_bvh() -> (BVH, Vec<UnitBox>) {
+    /// #     let mut shapes = Vec::new();
+    /// #     for i in 0..1000 {
+    /// #         let position = Point3::new(i as f32, i as f32, i as f32);
+    /// #         shapes.push(UnitBox::new(i, position));
+    /// #     }
+    /// #     let bvh = BVH::build(&mut shapes);
+    /// #     (bvh, shapes)
+    /// # }
+    ///
+    /// let (bvh, shapes) = create_bvh();
+    ///
+    /// let pt = Point3::new(3.0, 1.0, -1.0);
+    /// let hit_shapes = bvh.traverse_pt(&pt, &shapes);
+    /// ```
+    ///
+    /// [`BoundingHierarchy`]: trait.BoundingHierarchy.html
+    /// [`AABB`]: ../aabb/struct.AABB.html
+    ///
+    fn traverse_pt<'a, Shape: BHShape>(&'a self, pt: &Point3<f32>, shapes: &'a [Shape]) -> Vec<&Shape>;
 
     /// Prints the [`BoundingHierarchy`] in a tree-like visualization.
     ///

--- a/src/testbase.rs
+++ b/src/testbase.rs
@@ -102,6 +102,22 @@ fn traverse_and_verify<BH: BoundingHierarchy>(
     }
 }
 
+/// Given a point, a bounding hierarchy, the complete list of shapes in the scene and a list of
+/// expected hits, verifies, whether the point is contained only within the expected shapes.
+fn traverse_pt_and_verify<BH: BoundingHierarchy>(
+    pt: Point3<f32>,
+    all_shapes: &Vec<UnitBox>,
+    bh: &BH,
+    expected_shapes: &HashSet<i32>,
+) {
+    let hit_shapes = bh.traverse_pt(&pt, all_shapes);
+
+    assert_eq!(expected_shapes.len(), hit_shapes.len());
+    for shape in hit_shapes {
+        assert!(expected_shapes.contains(&shape.id));
+    }
+}
+
 /// Perform some fixed intersection tests on BH structures.
 pub fn traverse_some_bh<BH: BoundingHierarchy>() {
     let (all_shapes, bh) = build_some_bh::<BH>();
@@ -142,6 +158,19 @@ pub fn traverse_some_bh<BH: BoundingHierarchy>() {
         expected_shapes.insert(6);
         traverse_and_verify(origin, direction, &all_shapes, &bh, &expected_shapes);
     }
+}
+
+/// Perform some fixed intersection tests on BH structures.
+pub fn traverse_pt_some_bh<BH: BoundingHierarchy>() {
+    let (all_shapes, bh) = build_some_bh::<BH>();
+
+    // Define a ray which traverses the x-axis from afar.
+    let pt = Point3::new(5.0, 0.0, 0.0);
+    let mut expected_shapes = HashSet::new();
+
+    // It should hit a single box
+    expected_shapes.insert(5);
+    traverse_pt_and_verify(pt, &all_shapes, &bh, &expected_shapes);
 }
 
 /// A triangle struct. Instance of a more complex `Bounded` primitive.

--- a/src/testbase.rs
+++ b/src/testbase.rs
@@ -164,7 +164,7 @@ pub fn traverse_some_bh<BH: BoundingHierarchy>() {
 pub fn traverse_pt_some_bh<BH: BoundingHierarchy>() {
     let (all_shapes, bh) = build_some_bh::<BH>();
 
-    // Define a ray which traverses the x-axis from afar.
+    // Define a point which is contained inside one of the boxes
     let pt = Point3::new(5.0, 0.0, 0.0);
     let mut expected_shapes = HashSet::new();
 


### PR DESCRIPTION
For issue #42 

This is just some quick code I whipped up to get it working for my use case. It includes a traversal for the points, and it would make sense to add traverse for any `Bounded` object. What would be the best way to generalize the traversal for all these different use cases?

One way would be to have a single traverse function that takes an argument `f`, which is a function that takes an AABB and returns whether or not there was a "hit". So, the ray traversal could be implemented as:

```rust
    pub fn traverse<'a, Shape: Bounded>(&'a self, ray: &Ray, shapes: &'a [Shape]) -> Vec<&Shape> {
        let mut indices = Vec::new();
        BVHNode::traverse_recursive(&self.nodes, 0, |&aabb| ray.intersects(aabb), &mut indices);
        indices
            .iter()
            .map(|index| &shapes[*index])
            .collect::<Vec<_>>()
    }
```