### PR TITLE
Port from nalgebra to glam

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ license = "MIT"
 
 [dependencies]
 approx = "0.4"
-nalgebra = "0.26"
 rand = "0.8"
 log = "0.4"
 num = "0.4"
+glam = "0.13.0"
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ intersection test complexity is reduced from O(n) to O(log2(n)) at the cost of b
 the BVH once in advance. This technique is especially useful in ray/path tracers. For
 use in a shader this module also exports a flattening procedure, which allows for
 iterative traversal of the BVH.
-This library is built on top of [nalgebra](http://nalgebra.org/).
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This library is built on top of [nalgebra](http://nalgebra.org/).
 ```rust
 use bvh::aabb::{AABB, Bounded};
 use bvh::bvh::BVH;
-use bvh::nalgebra::{Point3, Vector3};
+use bvh::{Point3, Vector3};
 use bvh::ray::Ray;
 
 let origin = Point3::new(0.0,0.0,0.0);
@@ -33,7 +33,7 @@ let direction = Vector3::new(1.0,0.0,0.0);
 let ray = Ray::new(origin, direction);
 
 struct Sphere {
-    position: Point3<f32>,
+    position: Point3,
     radius: f32,
 }
 

--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -4,8 +4,7 @@ use std::f32;
 use std::fmt;
 use std::ops::Index;
 
-use approx::relative_eq;
-use nalgebra::{Point3, Vector3};
+use crate::{Point3, Vector3};
 
 use crate::axis::Axis;
 
@@ -14,10 +13,10 @@ use crate::axis::Axis;
 #[allow(clippy::upper_case_acronyms)]
 pub struct AABB {
     /// Minimum coordinates
-    pub min: Point3<f32>,
+    pub min: Point3,
 
     /// Maximum coordinates
-    pub max: Point3<f32>,
+    pub max: Point3,
 }
 
 impl fmt::Display for AABB {
@@ -36,7 +35,7 @@ pub trait Bounded {
     /// # Examples
     /// ```
     /// use bvh::aabb::{AABB, Bounded};
-    /// use bvh::nalgebra::Point3;
+    /// use bvh::Point3;
     ///
     /// struct Something;
     ///
@@ -66,7 +65,7 @@ impl AABB {
     /// # Examples
     /// ```
     /// use bvh::aabb::AABB;
-    /// use bvh::nalgebra::Point3;
+    /// use bvh::Point3;
     ///
     /// let aabb = AABB::with_bounds(Point3::new(-1.0,-1.0,-1.0), Point3::new(1.0,1.0,1.0));
     /// assert_eq!(aabb.min.x, -1.0);
@@ -75,7 +74,7 @@ impl AABB {
     ///
     /// [`AABB`]: struct.AABB.html
     ///
-    pub fn with_bounds(min: Point3<f32>, max: Point3<f32>) -> AABB {
+    pub fn with_bounds(min: Point3, max: Point3) -> AABB {
         AABB { min, max }
     }
 
@@ -117,7 +116,7 @@ impl AABB {
     /// # Examples
     /// ```
     /// use bvh::aabb::AABB;
-    /// use bvh::nalgebra::Point3;
+    /// use bvh::Point3;
     ///
     /// let aabb = AABB::with_bounds(Point3::new(-1.0, -1.0, -1.0), Point3::new(1.0, 1.0, 1.0));
     /// let point_inside = Point3::new(0.125, -0.25, 0.5);
@@ -130,7 +129,7 @@ impl AABB {
     /// [`AABB`]: struct.AABB.html
     /// [`Point3`]: http://nalgebra.org/doc/nalgebra/struct.Point3.html
     ///
-    pub fn contains(&self, p: &Point3<f32>) -> bool {
+    pub fn contains(&self, p: &Point3) -> bool {
         p.x >= self.min.x
             && p.x <= self.max.x
             && p.y >= self.min.y
@@ -146,7 +145,7 @@ impl AABB {
     /// ```
     /// use bvh::EPSILON;
     /// use bvh::aabb::AABB;
-    /// use bvh::nalgebra::Point3;
+    /// use bvh::Point3;
     ///
     /// let aabb = AABB::with_bounds(Point3::new(-1.0, -1.0, -1.0), Point3::new(1.0, 1.0, 1.0));
     /// let point_barely_outside = Point3::new(1.000_000_1, -1.000_000_1, 1.000_000_001);
@@ -159,7 +158,7 @@ impl AABB {
     /// [`AABB`]: struct.AABB.html
     /// [`Point3`]: http://nalgebra.org/doc/nalgebra/struct.Point3.html
     ///
-    pub fn approx_contains_eps(&self, p: &Point3<f32>, epsilon: f32) -> bool {
+    pub fn approx_contains_eps(&self, p: &Point3, epsilon: f32) -> bool {
         (p.x - self.min.x) > -epsilon
             && (p.x - self.max.x) < epsilon
             && (p.y - self.min.y) > -epsilon
@@ -175,7 +174,7 @@ impl AABB {
     /// ```
     /// use bvh::EPSILON;
     /// use bvh::aabb::AABB;
-    /// use bvh::nalgebra::Point3;
+    /// use bvh::Point3;
     ///
     /// let aabb = AABB::with_bounds(Point3::new(-1.0, -1.0, -1.0), Point3::new(1.0, 1.0, 1.0));
     /// let point_barely_outside = Point3::new(1.000_000_1, 1.000_000_1, 1.000_000_1);
@@ -198,7 +197,7 @@ impl AABB {
     /// ```
     /// use bvh::EPSILON;
     /// use bvh::aabb::AABB;
-    /// use bvh::nalgebra::Point3;
+    /// use bvh::Point3;
     ///
     /// let aabb = AABB::with_bounds(Point3::new(-1.0, -1.0, -1.0), Point3::new(1.0, 1.0, 1.0));
     /// let point_barely_outside_min = Point3::new(-1.000_000_1, -1.000_000_1, -1.000_000_1);
@@ -210,8 +209,12 @@ impl AABB {
     ///
     /// [`AABB`]: struct.AABB.html
     pub fn relative_eq(&self, other: &AABB, epsilon: f32) -> bool {
-        relative_eq!(self.min, other.min, epsilon = epsilon)
-            && relative_eq!(self.max, other.max, epsilon = epsilon)
+        f32::abs(self.min.x - other.min.x) < epsilon &&
+            f32::abs(self.min.y - other.min.y) < epsilon &&
+            f32::abs(self.min.z - other.min.z) < epsilon &&
+            f32::abs(self.max.x - other.max.x) < epsilon &&
+            f32::abs(self.max.y - other.max.y) < epsilon &&
+            f32::abs(self.max.z - other.max.z) < epsilon
     }
 
     /// Returns a new minimal [`AABB`] which contains both this [`AABB`] and `other`.
@@ -220,7 +223,7 @@ impl AABB {
     /// # Examples
     /// ```
     /// use bvh::aabb::AABB;
-    /// use bvh::nalgebra::Point3;
+    /// use bvh::Point3;
     ///
     /// let aabb1 = AABB::with_bounds(Point3::new(-101.0, 0.0, 0.0), Point3::new(-100.0, 1.0, 1.0));
     /// let aabb2 = AABB::with_bounds(Point3::new(100.0, 0.0, 0.0), Point3::new(101.0, 1.0, 1.0));
@@ -265,7 +268,7 @@ impl AABB {
     /// # Examples
     /// ```
     /// use bvh::aabb::AABB;
-    /// use bvh::nalgebra::{Point3, Vector3};
+    /// use bvh::{Point3, Vector3};
     ///
     /// let size = Vector3::new(1.0, 1.0, 1.0);
     /// let aabb_pos = Point3::new(-101.0, 0.0, 0.0);
@@ -314,7 +317,7 @@ impl AABB {
     /// # Examples
     /// ```
     /// use bvh::aabb::AABB;
-    /// use bvh::nalgebra::Point3;
+    /// use bvh::Point3;
     ///
     /// let point1 = Point3::new(0.0, 0.0, 0.0);
     /// let point2 = Point3::new(1.0, 1.0, 1.0);
@@ -334,7 +337,7 @@ impl AABB {
     /// [`AABB`]: struct.AABB.html
     /// [`Point3`]: http://nalgebra.org/doc/nalgebra/struct.Point3.html
     ///
-    pub fn grow(&self, other: &Point3<f32>) -> AABB {
+    pub fn grow(&self, other: &Point3) -> AABB {
         AABB::with_bounds(
             Point3::new(
                 self.min.x.min(other.x),
@@ -354,7 +357,7 @@ impl AABB {
     /// # Examples
     /// ```
     /// use bvh::aabb::AABB;
-    /// use bvh::nalgebra::Point3;
+    /// use bvh::Point3;
     ///
     /// let point1 = Point3::new(0.0, 0.0, 0.0);
     /// let point2 = Point3::new(1.0, 1.0, 1.0);
@@ -375,7 +378,7 @@ impl AABB {
     /// [`AABB::grow`]: struct.AABB.html
     /// [`Point3`]: http://nalgebra.org/doc/nalgebra/struct.Point3.html
     ///
-    pub fn grow_mut(&mut self, other: &Point3<f32>) {
+    pub fn grow_mut(&mut self, other: &Point3) {
         self.min = Point3::new(
             self.min.x.min(other.x),
             self.min.y.min(other.y),
@@ -394,7 +397,7 @@ impl AABB {
     /// # Examples
     /// ```
     /// use bvh::aabb::{AABB, Bounded};
-    /// use bvh::nalgebra::Point3;
+    /// use bvh::Point3;
     ///
     /// struct Something;
     ///
@@ -426,7 +429,7 @@ impl AABB {
     /// # Examples
     /// ```
     /// use bvh::aabb::AABB;
-    /// use bvh::nalgebra::Point3;
+    /// use bvh::Point3;
     ///
     /// let aabb = AABB::with_bounds(Point3::new(-1.0,-1.0,-1.0), Point3::new(1.0,1.0,1.0));
     /// let size = aabb.size();
@@ -435,7 +438,7 @@ impl AABB {
     ///
     /// [`AABB`]: struct.AABB.html
     ///
-    pub fn size(&self) -> Vector3<f32> {
+    pub fn size(&self) -> Vector3 {
         self.max - self.min
     }
 
@@ -444,7 +447,7 @@ impl AABB {
     /// # Examples
     /// ```
     /// use bvh::aabb::AABB;
-    /// use bvh::nalgebra::Point3;
+    /// use bvh::Point3;
     ///
     /// let min = Point3::new(41.0,41.0,41.0);
     /// let max = Point3::new(43.0,43.0,43.0);
@@ -457,7 +460,7 @@ impl AABB {
     /// [`AABB`]: struct.AABB.html
     /// [`Point3`]: http://nalgebra.org/doc/nalgebra/struct.Point3.html
     ///
-    pub fn center(&self) -> Point3<f32> {
+    pub fn center(&self) -> Point3 {
         self.min + (self.size() / 2.0)
     }
 
@@ -467,7 +470,7 @@ impl AABB {
     /// # Examples
     /// ```
     /// use bvh::aabb::AABB;
-    /// use bvh::nalgebra::Point3;
+    /// use bvh::Point3;
     ///
     /// let empty_aabb = AABB::empty();
     /// assert!(empty_aabb.is_empty());
@@ -490,7 +493,7 @@ impl AABB {
     /// # Examples
     /// ```
     /// use bvh::aabb::AABB;
-    /// use bvh::nalgebra::Point3;
+    /// use bvh::Point3;
     ///
     /// let min = Point3::new(41.0,41.0,41.0);
     /// let max = Point3::new(43.0,43.0,43.0);
@@ -512,7 +515,7 @@ impl AABB {
     /// # Examples
     /// ```
     /// use bvh::aabb::AABB;
-    /// use bvh::nalgebra::Point3;
+    /// use bvh::Point3;
     ///
     /// let min = Point3::new(41.0,41.0,41.0);
     /// let max = Point3::new(43.0,43.0,43.0);
@@ -535,7 +538,7 @@ impl AABB {
     /// ```
     /// use bvh::aabb::AABB;
     /// use bvh::axis::Axis;
-    /// use bvh::nalgebra::Point3;
+    /// use bvh::Point3;
     ///
     /// let min = Point3::new(-100.0,0.0,0.0);
     /// let max = Point3::new(100.0,0.0,0.0);
@@ -576,7 +579,7 @@ impl Default for AABB {
 /// # Examples
 /// ```
 /// use bvh::aabb::AABB;
-/// use bvh::nalgebra::Point3;
+/// use bvh::Point3;
 ///
 /// let min = Point3::new(3.0,4.0,5.0);
 /// let max = Point3::new(123.0,123.0,123.0);
@@ -589,9 +592,9 @@ impl Default for AABB {
 /// [`AABB`]: struct.AABB.html
 ///
 impl Index<usize> for AABB {
-    type Output = Point3<f32>;
+    type Output = Point3;
 
-    fn index(&self, index: usize) -> &Point3<f32> {
+    fn index(&self, index: usize) -> &Point3 {
         if index == 0 {
             &self.min
         } else {
@@ -605,7 +608,7 @@ impl Index<usize> for AABB {
 /// # Examples
 /// ```
 /// use bvh::aabb::{AABB, Bounded};
-/// use bvh::nalgebra::Point3;
+/// use bvh::Point3;
 ///
 /// let point_a = Point3::new(3.0,4.0,5.0);
 /// let point_b = Point3::new(17.0,18.0,19.0);
@@ -631,7 +634,7 @@ impl Bounded for AABB {
 /// # Examples
 /// ```
 /// use bvh::aabb::{AABB, Bounded};
-/// use bvh::nalgebra::Point3;
+/// use bvh::Point3;
 ///
 /// let point = Point3::new(3.0,4.0,5.0);
 ///
@@ -642,7 +645,7 @@ impl Bounded for AABB {
 /// [`Bounded`]: trait.Bounded.html
 /// [`Point3`]: http://nalgebra.org/doc/nalgebra/struct.Point3.html
 ///
-impl Bounded for Point3<f32> {
+impl Bounded for Point3 {
     fn aabb(&self) -> AABB {
         AABB::with_bounds(*self, *self)
     }
@@ -654,7 +657,7 @@ mod tests {
     use crate::testbase::{tuple_to_point, tuple_to_vector, TupleVec};
     use crate::EPSILON;
 
-    use nalgebra::{Point3, Vector3};
+    use crate::{Point3, Vector3};
     use quickcheck::quickcheck;
 
     // Test whether an empty `AABB` does not contains anything.
@@ -709,7 +712,7 @@ mod tests {
             let points = [a.0, a.1, a.2, a.3, a.4, b.0, b.1, b.2, b.3, b.4];
 
             // Convert these points to `Point3`
-            let points = points.iter().map(tuple_to_point).collect::<Vec<Point3<f32>>>();
+            let points = points.iter().map(tuple_to_point).collect::<Vec<Point3>>();
 
             // Create two `AABB`s. One spanned the first five points,
             // the other by the last five points

--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -127,7 +127,7 @@ impl AABB {
     /// ```
     ///
     /// [`AABB`]: struct.AABB.html
-    /// [`Point3`]: http://nalgebra.org/doc/nalgebra/struct.Point3.html
+    /// [`Point3`]: glam::Vec3
     ///
     pub fn contains(&self, p: &Point3) -> bool {
         p.x >= self.min.x
@@ -156,7 +156,7 @@ impl AABB {
     /// ```
     ///
     /// [`AABB`]: struct.AABB.html
-    /// [`Point3`]: http://nalgebra.org/doc/nalgebra/struct.Point3.html
+    /// [`Point3`]: glam::Vec3
     ///
     pub fn approx_contains_eps(&self, p: &Point3, epsilon: f32) -> bool {
         (p.x - self.min.x) > -epsilon
@@ -335,7 +335,7 @@ impl AABB {
     /// ```
     ///
     /// [`AABB`]: struct.AABB.html
-    /// [`Point3`]: http://nalgebra.org/doc/nalgebra/struct.Point3.html
+    /// [`Point3`]: glam::Vec3
     ///
     pub fn grow(&self, other: &Point3) -> AABB {
         AABB::with_bounds(
@@ -376,7 +376,7 @@ impl AABB {
     /// ```
     ///
     /// [`AABB::grow`]: struct.AABB.html
-    /// [`Point3`]: http://nalgebra.org/doc/nalgebra/struct.Point3.html
+    /// [`Point3`]: glam::Vec3
     ///
     pub fn grow_mut(&mut self, other: &Point3) {
         self.min = Point3::new(
@@ -458,7 +458,7 @@ impl AABB {
     /// ```
     ///
     /// [`AABB`]: struct.AABB.html
-    /// [`Point3`]: http://nalgebra.org/doc/nalgebra/struct.Point3.html
+    /// [`Point3`]: glam::Vec3
     ///
     pub fn center(&self) -> Point3 {
         self.min + (self.size() / 2.0)
@@ -643,7 +643,7 @@ impl Bounded for AABB {
 /// ```
 ///
 /// [`Bounded`]: trait.Bounded.html
-/// [`Point3`]: http://nalgebra.org/doc/nalgebra/struct.Point3.html
+/// [`Point3`]: glam::Vec3
 ///
 impl Bounded for Point3 {
     fn aabb(&self) -> AABB {

--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -209,12 +209,12 @@ impl AABB {
     ///
     /// [`AABB`]: struct.AABB.html
     pub fn relative_eq(&self, other: &AABB, epsilon: f32) -> bool {
-        f32::abs(self.min.x - other.min.x) < epsilon &&
-            f32::abs(self.min.y - other.min.y) < epsilon &&
-            f32::abs(self.min.z - other.min.z) < epsilon &&
-            f32::abs(self.max.x - other.max.x) < epsilon &&
-            f32::abs(self.max.y - other.max.y) < epsilon &&
-            f32::abs(self.max.z - other.max.z) < epsilon
+        f32::abs(self.min.x - other.min.x) < epsilon
+            && f32::abs(self.min.y - other.min.y) < epsilon
+            && f32::abs(self.min.z - other.min.z) < epsilon
+            && f32::abs(self.max.x - other.max.x) < epsilon
+            && f32::abs(self.max.y - other.max.y) < epsilon
+            && f32::abs(self.max.z - other.max.z) < epsilon
     }
 
     /// Returns a new minimal [`AABB`] which contains both this [`AABB`] and `other`.

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -1,7 +1,7 @@
 //! Axis enum for indexing three-dimensional structures.
 
 #![allow(unused)]
-use nalgebra::{Point3, Vector3};
+use crate::{Point3, Vector3};
 use std::fmt::{Display, Formatter, Result};
 use std::ops::{Index, IndexMut};
 
@@ -26,13 +26,12 @@ struct MyType<T>(T);
 ///
 /// ```
 /// extern crate bvh;
-/// extern crate nalgebra;
 ///
 /// use bvh::axis::Axis;
-/// use nalgebra::Point3;
+/// use bvh::Point3;
 ///
 /// # fn main() {
-/// let mut position: Point3<f32> = Point3::new(1.0, 2.0, 3.0);
+/// let mut position: Point3 = Point3::new(1.0, 2.0, 3.0);
 /// position[Axis::X] = 1000.0;
 ///
 /// assert_eq!(position[Axis::X], 1000.0);
@@ -75,7 +74,7 @@ impl Index<Axis> for [f32] {
 }
 
 /// Make `Point3` indexable by `Axis`.
-impl Index<Axis> for Point3<f32> {
+impl Index<Axis> for Point3 {
     type Output = f32;
 
     fn index(&self, axis: Axis) -> &f32 {
@@ -88,7 +87,7 @@ impl Index<Axis> for Point3<f32> {
 }
 
 /// Make `Vector3` indexable by `Axis`.
-impl Index<Axis> for MyType<Vector3<f32>> {
+impl Index<Axis> for MyType<Vector3> {
     type Output = f32;
 
     fn index(&self, axis: Axis) -> &f32 {
@@ -108,7 +107,7 @@ impl IndexMut<Axis> for [f32] {
 }
 
 /// Make `Point3` mutably accessible by `Axis`.
-impl IndexMut<Axis> for Point3<f32> {
+impl IndexMut<Axis> for Point3 {
     fn index_mut(&mut self, axis: Axis) -> &mut f32 {
         match axis {
             Axis::X => &mut self.x,
@@ -119,7 +118,7 @@ impl IndexMut<Axis> for Point3<f32> {
 }
 
 /// Make `Vector3` mutably accessible by `Axis`.
-impl IndexMut<Axis> for MyType<Vector3<f32>> {
+impl IndexMut<Axis> for MyType<Vector3> {
     fn index_mut(&mut self, axis: Axis) -> &mut f32 {
         match axis {
             Axis::X => &mut self.0.x,

--- a/src/axis.rs
+++ b/src/axis.rs
@@ -20,9 +20,7 @@ struct MyType<T>(T);
 /// assert_eq!(position[Axis::Y], 2.0);
 /// ```
 ///
-/// `nalgebra` structures are also indexable using `Axis`.
-/// For reference see [the documentation]
-/// (http://nalgebra.org/doc/nalgebra/struct.Vector3.html#method.index).
+/// [`Point3`] and [`Vector3`] are also indexable using `Axis`.
 ///
 /// ```
 /// extern crate bvh;

--- a/src/bounding_hierarchy.rs
+++ b/src/bounding_hierarchy.rs
@@ -33,16 +33,16 @@ pub trait BoundingHierarchy {
     /// ```
     /// use bvh::aabb::{AABB, Bounded};
     /// use bvh::bounding_hierarchy::BoundingHierarchy;
-    /// use bvh::nalgebra::{Point3, Vector3};
+    /// use bvh::{Point3, Vector3};
     /// # use bvh::bounding_hierarchy::BHShape;
     /// # pub struct UnitBox {
     /// #     pub id: i32,
-    /// #     pub pos: Point3<f32>,
+    /// #     pub pos: Point3,
     /// #     node_index: usize,
     /// # }
     /// #
     /// # impl UnitBox {
-    /// #     pub fn new(id: i32, pos: Point3<f32>) -> UnitBox {
+    /// #     pub fn new(id: i32, pos: Point3) -> UnitBox {
     /// #         UnitBox {
     /// #             id: id,
     /// #             pos: pos,
@@ -105,17 +105,17 @@ pub trait BoundingHierarchy {
     /// use bvh::aabb::{AABB, Bounded};
     /// use bvh::bounding_hierarchy::BoundingHierarchy;
     /// use bvh::bvh::BVH;
-    /// use bvh::nalgebra::{Point3, Vector3};
+    /// use bvh::{Point3, Vector3};
     /// use bvh::ray::Ray;
     /// # use bvh::bounding_hierarchy::BHShape;
     /// # pub struct UnitBox {
     /// #     pub id: i32,
-    /// #     pub pos: Point3<f32>,
+    /// #     pub pos: Point3,
     /// #     node_index: usize,
     /// # }
     /// #
     /// # impl UnitBox {
-    /// #     pub fn new(id: i32, pos: Point3<f32>) -> UnitBox {
+    /// #     pub fn new(id: i32, pos: Point3) -> UnitBox {
     /// #         UnitBox {
     /// #             id: id,
     /// #             pos: pos,

--- a/src/bvh/bvh_impl.rs
+++ b/src/bvh/bvh_impl.rs
@@ -9,8 +9,8 @@ use crate::bounding_hierarchy::{BHShape, BoundingHierarchy};
 use crate::bvh::iter::BVHTraverseIterator;
 use crate::ray::Ray;
 use crate::utils::{concatenate_vectors, joint_aabb_of_shapes, Bucket};
-use crate::EPSILON;
 use crate::Point3;
+use crate::EPSILON;
 use std::f32;
 use std::iter::repeat;
 

--- a/src/bvh/bvh_impl.rs
+++ b/src/bvh/bvh_impl.rs
@@ -10,7 +10,7 @@ use crate::bvh::iter::BVHTraverseIterator;
 use crate::ray::Ray;
 use crate::utils::{concatenate_vectors, joint_aabb_of_shapes, Bucket};
 use crate::EPSILON;
-use nalgebra::Point3;
+use crate::Point3;
 use std::f32;
 use std::iter::repeat;
 

--- a/src/bvh/iter.rs
+++ b/src/bvh/iter.rs
@@ -146,7 +146,7 @@ mod tests {
     use crate::bvh::BVH;
     use crate::ray::Ray;
     use crate::testbase::{generate_aligned_boxes, UnitBox};
-    use nalgebra::{Point3, Vector3};
+    use crate::{Point3, Vector3};
     use std::collections::HashSet;
 
     /// Creates a `BVH` for a fixed scene structure.
@@ -159,8 +159,8 @@ mod tests {
     /// Given a ray, a bounding hierarchy, the complete list of shapes in the scene and a list of
     /// expected hits, verifies, whether the ray hits only the expected shapes.
     fn traverse_and_verify_vec(
-        ray_origin: Point3<f32>,
-        ray_direction: Vector3<f32>,
+        ray_origin: Point3,
+        ray_direction: Vector3,
         all_shapes: &Vec<UnitBox>,
         bvh: &BVH,
         expected_shapes: &HashSet<i32>,
@@ -175,8 +175,8 @@ mod tests {
     }
 
     fn traverse_and_verify_iterator(
-        ray_origin: Point3<f32>,
-        ray_direction: Vector3<f32>,
+        ray_origin: Point3,
+        ray_direction: Vector3,
         all_shapes: &Vec<UnitBox>,
         bvh: &BVH,
         expected_shapes: &HashSet<i32>,
@@ -193,8 +193,8 @@ mod tests {
     }
 
     fn traverse_and_verify_base(
-        ray_origin: Point3<f32>,
-        ray_direction: Vector3<f32>,
+        ray_origin: Point3,
+        ray_direction: Vector3,
         all_shapes: &Vec<UnitBox>,
         bvh: &BVH,
         expected_shapes: &HashSet<i32>,

--- a/src/bvh/optimization.rs
+++ b/src/bvh/optimization.rs
@@ -520,8 +520,8 @@ mod tests {
     use crate::testbase::{
         build_some_bh, create_n_cubes, default_bounds, randomly_transform_scene, UnitBox,
     };
-    use crate::EPSILON;
     use crate::Point3;
+    use crate::EPSILON;
     use std::collections::HashSet;
 
     #[test]

--- a/src/bvh/optimization.rs
+++ b/src/bvh/optimization.rs
@@ -521,7 +521,7 @@ mod tests {
         build_some_bh, create_n_cubes, default_bounds, randomly_transform_scene, UnitBox,
     };
     use crate::EPSILON;
-    use nalgebra::Point3;
+    use crate::Point3;
     use std::collections::HashSet;
 
     #[test]

--- a/src/flat_bvh.rs
+++ b/src/flat_bvh.rs
@@ -160,17 +160,17 @@ impl BVH {
     /// ```
     /// use bvh::aabb::{AABB, Bounded};
     /// use bvh::bvh::BVH;
-    /// use bvh::nalgebra::{Point3, Vector3};
+    /// use bvh::{Point3, Vector3};
     /// use bvh::ray::Ray;
     /// # use bvh::bounding_hierarchy::BHShape;
     /// # pub struct UnitBox {
     /// #     pub id: i32,
-    /// #     pub pos: Point3<f32>,
+    /// #     pub pos: Point3,
     /// #     node_index: usize,
     /// # }
     /// #
     /// # impl UnitBox {
-    /// #     pub fn new(id: i32, pos: Point3<f32>) -> UnitBox {
+    /// #     pub fn new(id: i32, pos: Point3) -> UnitBox {
     /// #         UnitBox {
     /// #             id: id,
     /// #             pos: pos,
@@ -244,17 +244,17 @@ impl BVH {
     /// ```
     /// use bvh::aabb::{AABB, Bounded};
     /// use bvh::bvh::BVH;
-    /// use bvh::nalgebra::{Point3, Vector3};
+    /// use bvh::{Point3, Vector3};
     /// use bvh::ray::Ray;
     /// # use bvh::bounding_hierarchy::BHShape;
     /// # pub struct UnitBox {
     /// #     pub id: i32,
-    /// #     pub pos: Point3<f32>,
+    /// #     pub pos: Point3,
     /// #     node_index: usize,
     /// # }
     /// #
     /// # impl UnitBox {
-    /// #     pub fn new(id: i32, pos: Point3<f32>) -> UnitBox {
+    /// #     pub fn new(id: i32, pos: Point3) -> UnitBox {
     /// #         UnitBox {
     /// #             id: id,
     /// #             pos: pos,
@@ -325,17 +325,17 @@ impl BoundingHierarchy for FlatBVH {
     /// use bvh::aabb::{AABB, Bounded};
     /// use bvh::bounding_hierarchy::BoundingHierarchy;
     /// use bvh::flat_bvh::FlatBVH;
-    /// use bvh::nalgebra::{Point3, Vector3};
+    /// use bvh::{Point3, Vector3};
     /// use bvh::ray::Ray;
     /// # use bvh::bounding_hierarchy::BHShape;
     /// # pub struct UnitBox {
     /// #     pub id: i32,
-    /// #     pub pos: Point3<f32>,
+    /// #     pub pos: Point3,
     /// #     node_index: usize,
     /// # }
     /// #
     /// # impl UnitBox {
-    /// #     pub fn new(id: i32, pos: Point3<f32>) -> UnitBox {
+    /// #     pub fn new(id: i32, pos: Point3) -> UnitBox {
     /// #         UnitBox {
     /// #             id: id,
     /// #             pos: pos,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,6 @@
 //! the BVH once in advance. This technique is especially useful in ray/path tracers. For
 //! use in a shader this module also exports a flattening procedure, which allows for
 //! iterative traversal of the BVH.
-//! This library is built on top of [`nalgebra`].
 //!
 //! ## Example
 //!
@@ -64,8 +63,6 @@
 //! let bvh = BVH::build(&mut spheres);
 //! let hit_sphere_aabbs = bvh.traverse(&ray, &spheres);
 //! ```
-//!
-//! [`nalgebra`]: http://nalgebra.org/doc/nalgebra/
 //!
 
 #![deny(missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! use bvh::aabb::{AABB, Bounded};
 //! use bvh::bounding_hierarchy::{BoundingHierarchy, BHShape};
 //! use bvh::bvh::BVH;
-//! use bvh::nalgebra::{Point3, Vector3};
+//! use bvh::{Point3, Vector3};
 //! use bvh::ray::Ray;
 //!
 //! let origin = Point3::new(0.0,0.0,0.0);
@@ -26,7 +26,7 @@
 //! let ray = Ray::new(origin, direction);
 //!
 //! struct Sphere {
-//!     position: Point3<f32>,
+//!     position: Point3,
 //!     radius: f32,
 //!     node_index: usize,
 //! }
@@ -74,11 +74,17 @@
 #[cfg(all(feature = "bench", test))]
 extern crate test;
 
-pub use nalgebra;
+use glam;
 
 /// A minimal floating value used as a lower bound.
 /// TODO: replace by/add ULPS/relative float comparison methods.
 pub const EPSILON: f32 = 0.00001;
+
+/// Point math type used by this crate. Type alias for [`glam::Vec3`].
+pub type Point3 = glam::Vec3;
+
+/// Vector math type used by this crate. Type alias for [`glam::Vec3`].
+pub type Vector3 = glam::Vec3;
 
 pub mod aabb;
 pub mod axis;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,8 +71,6 @@
 #[cfg(all(feature = "bench", test))]
 extern crate test;
 
-use glam;
-
 /// A minimal floating value used as a lower bound.
 /// TODO: replace by/add ULPS/relative float comparison methods.
 pub const EPSILON: f32 = 0.00001;

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -3,30 +3,44 @@
 
 use crate::aabb::AABB;
 use crate::EPSILON;
-use nalgebra::{Point3, Vector3};
+use crate::{Point3, Vector3};
 use std::f32::INFINITY;
 
 /// A struct which defines a ray and some of its cached values.
 #[derive(Debug)]
 pub struct Ray {
     /// The ray origin.
-    pub origin: Point3<f32>,
+    pub origin: Point3,
 
     /// The ray direction.
-    pub direction: Vector3<f32>,
+    pub direction: Vector3,
 
     /// Inverse (1/x) ray direction. Cached for use in [`AABB`] intersections.
     ///
     /// [`AABB`]: struct.AABB.html
     ///
-    inv_direction: Vector3<f32>,
+    inv_direction: Vector3,
 
-    /// Sign of the direction. 0 means positive, 1 means negative.
+    /// Sign of the X direction. 0 means positive, 1 means negative.
     /// Cached for use in [`AABB`] intersections.
     ///
     /// [`AABB`]: struct.AABB.html
     ///
-    sign: Vector3<usize>,
+    sign_x: usize,
+
+    /// Sign of the Y direction. 0 means positive, 1 means negative.
+    /// Cached for use in [`AABB`] intersections.
+    ///
+    /// [`AABB`]: struct.AABB.html
+    ///
+    sign_y: usize,
+
+    /// Sign of the Z direction. 0 means positive, 1 means negative.
+    /// Cached for use in [`AABB`] intersections.
+    ///
+    /// [`AABB`]: struct.AABB.html
+    ///
+    sign_z: usize,
 }
 
 /// A struct which is returned by the `intersects_triangle` method.
@@ -56,7 +70,7 @@ impl Ray {
     /// # Examples
     /// ```
     /// use bvh::ray::Ray;
-    /// use bvh::nalgebra::{Point3,Vector3};
+    /// use bvh::{Point3,Vector3};
     ///
     /// let origin = Point3::new(0.0,0.0,0.0);
     /// let direction = Vector3::new(1.0,0.0,0.0);
@@ -68,17 +82,15 @@ impl Ray {
     ///
     /// [`Ray`]: struct.Ray.html
     ///
-    pub fn new(origin: Point3<f32>, direction: Vector3<f32>) -> Ray {
+    pub fn new(origin: Point3, direction: Vector3) -> Ray {
         let direction = direction.normalize();
         Ray {
             origin,
             direction,
             inv_direction: Vector3::new(1.0 / direction.x, 1.0 / direction.y, 1.0 / direction.z),
-            sign: Vector3::new(
-                (direction.x < 0.0) as usize,
-                (direction.y < 0.0) as usize,
-                (direction.z < 0.0) as usize,
-            ),
+            sign_x: (direction.x < 0.0) as usize,
+            sign_y: (direction.y < 0.0) as usize,
+            sign_z: (direction.z < 0.0) as usize,
         }
     }
 
@@ -89,7 +101,7 @@ impl Ray {
     /// ```
     /// use bvh::aabb::AABB;
     /// use bvh::ray::Ray;
-    /// use bvh::nalgebra::{Point3,Vector3};
+    /// use bvh::{Point3,Vector3};
     ///
     /// let origin = Point3::new(0.0,0.0,0.0);
     /// let direction = Vector3::new(1.0,0.0,0.0);
@@ -106,11 +118,11 @@ impl Ray {
     /// [`AABB`]: struct.AABB.html
     ///
     pub fn intersects_aabb(&self, aabb: &AABB) -> bool {
-        let mut ray_min = (aabb[self.sign.x].x - self.origin.x) * self.inv_direction.x;
-        let mut ray_max = (aabb[1 - self.sign.x].x - self.origin.x) * self.inv_direction.x;
+        let mut ray_min = (aabb[self.sign_x].x - self.origin.x) * self.inv_direction.x;
+        let mut ray_max = (aabb[1 - self.sign_x].x - self.origin.x) * self.inv_direction.x;
 
-        let y_min = (aabb[self.sign.y].y - self.origin.y) * self.inv_direction.y;
-        let y_max = (aabb[1 - self.sign.y].y - self.origin.y) * self.inv_direction.y;
+        let y_min = (aabb[self.sign_y].y - self.origin.y) * self.inv_direction.y;
+        let y_max = (aabb[1 - self.sign_y].y - self.origin.y) * self.inv_direction.y;
 
         if (ray_min > y_max) || (y_min > ray_max) {
             return false;
@@ -128,8 +140,8 @@ impl Ray {
         // Using the following solution significantly decreases the performance
         // ray_max = ray_max.min(y_max);
 
-        let z_min = (aabb[self.sign.z].z - self.origin.z) * self.inv_direction.z;
-        let z_max = (aabb[1 - self.sign.z].z - self.origin.z) * self.inv_direction.z;
+        let z_min = (aabb[self.sign_z].z - self.origin.z) * self.inv_direction.z;
+        let z_max = (aabb[1 - self.sign_z].z - self.origin.z) * self.inv_direction.z;
 
         if (ray_min > z_max) || (z_min > ray_max) {
             return false;
@@ -155,7 +167,7 @@ impl Ray {
     /// ```
     /// use bvh::aabb::AABB;
     /// use bvh::ray::Ray;
-    /// use bvh::nalgebra::{Point3,Vector3};
+    /// use bvh::{Point3,Vector3};
     ///
     /// let origin = Point3::new(0.0,0.0,0.0);
     /// let direction = Vector3::new(1.0,0.0,0.0);
@@ -201,7 +213,7 @@ impl Ray {
     /// ```
     /// use bvh::aabb::AABB;
     /// use bvh::ray::Ray;
-    /// use bvh::nalgebra::{Point3,Vector3};
+    /// use bvh::{Point3,Vector3};
     ///
     /// let origin = Point3::new(0.0,0.0,0.0);
     /// let direction = Vector3::new(1.0,0.0,0.0);
@@ -248,9 +260,9 @@ impl Ray {
     #[allow(clippy::many_single_char_names)]
     pub fn intersects_triangle(
         &self,
-        a: &Point3<f32>,
-        b: &Point3<f32>,
-        c: &Point3<f32>,
+        a: &Point3,
+        b: &Point3,
+        c: &Point3,
     ) -> Intersection {
         let a_to_b = *b - *a;
         let a_to_c = *c - *a;
@@ -258,12 +270,12 @@ impl Ray {
         // Begin calculating determinant - also used to calculate u parameter
         // u_vec lies in view plane
         // length of a_to_c in view_plane = |u_vec| = |a_to_c|*sin(a_to_c, dir)
-        let u_vec = self.direction.cross(&a_to_c);
+        let u_vec = self.direction.cross(a_to_c);
 
         // If determinant is near zero, ray lies in plane of triangle
         // The determinant corresponds to the parallelepiped volume:
         // det = 0 => [dir, a_to_b, a_to_c] not linearly independant
-        let det = a_to_b.dot(&u_vec);
+        let det = a_to_b.dot(u_vec);
 
         // Only testing positive bound, thus enabling backface culling
         // If backface culling is not desired write:
@@ -278,7 +290,7 @@ impl Ray {
         let a_to_origin = self.origin - *a;
 
         // Calculate u parameter
-        let u = a_to_origin.dot(&u_vec) * inv_det;
+        let u = a_to_origin.dot(u_vec) * inv_det;
 
         // Test bounds: u < 0 || u > 1 => outside of triangle
         if !(0.0..=1.0).contains(&u) {
@@ -286,16 +298,16 @@ impl Ray {
         }
 
         // Prepare to test v parameter
-        let v_vec = a_to_origin.cross(&a_to_b);
+        let v_vec = a_to_origin.cross(a_to_b);
 
         // Calculate v parameter and test bound
-        let v = self.direction.dot(&v_vec) * inv_det;
+        let v = self.direction.dot(v_vec) * inv_det;
         // The intersection lies outside of the triangle
         if v < 0.0 || u + v > 1.0 {
             return Intersection::new(INFINITY, u, v);
         }
 
-        let dist = a_to_c.dot(&v_vec) * inv_det;
+        let dist = a_to_c.dot(v_vec) * inv_det;
 
         if dist > EPSILON {
             Intersection::new(dist, u, v)
@@ -416,7 +428,7 @@ mod tests {
             let triangle = (tuple_to_point(&a), tuple_to_point(&b), tuple_to_point(&c));
             let u_vec = triangle.1 - triangle.0;
             let v_vec = triangle.2 - triangle.0;
-            let normal = u_vec.cross(&v_vec);
+            let normal = u_vec.cross(v_vec);
 
             // Get some u and v coordinates such that u+v <= 1
             let u = u % 101;
@@ -430,7 +442,7 @@ mod tests {
             // Define a ray which points at the triangle
             let origin = tuple_to_point(&origin);
             let ray = Ray::new(origin, point_on_triangle - origin);
-            let on_back_side = normal.dot(&(ray.origin - triangle.0)) <= 0.0;
+            let on_back_side = normal.dot(ray.origin - triangle.0) <= 0.0;
 
             // Perform the intersection test
             let intersects = ray.intersects_triangle(&triangle.0, &triangle.1, &triangle.2);

--- a/src/ray.rs
+++ b/src/ray.rs
@@ -258,12 +258,7 @@ impl Ray {
     /// The distance is set to +INFINITY if the ray does not intersect the triangle, or hits
     /// it from behind.
     #[allow(clippy::many_single_char_names)]
-    pub fn intersects_triangle(
-        &self,
-        a: &Point3,
-        b: &Point3,
-        c: &Point3,
-    ) -> Intersection {
+    pub fn intersects_triangle(&self, a: &Point3, b: &Point3, c: &Point3) -> Intersection {
         let a_to_b = *b - *a;
         let a_to_c = *c - *a;
 

--- a/src/testbase.rs
+++ b/src/testbase.rs
@@ -20,12 +20,12 @@ use crate::ray::Ray;
 /// A vector represented as a tuple
 pub type TupleVec = (f32, f32, f32);
 
-/// Convert a `TupleVec` to a `nalgebra` point.
+/// Convert a `TupleVec` to a [`Point3`].
 pub fn tuple_to_point(tpl: &TupleVec) -> Point3 {
     Point3::new(tpl.0, tpl.1, tpl.2)
 }
 
-/// Convert a `TupleVec` to a `nalgebra` vector.
+/// Convert a `TupleVec` to a [`Vector3`].
 pub fn tuple_to_vector(tpl: &TupleVec) -> Vector3 {
     Vector3::new(tpl.0, tpl.1, tpl.2)
 }

--- a/src/testbase.rs
+++ b/src/testbase.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use std::f32;
 use std::mem::transmute;
 
-use nalgebra::{Point3, Vector3};
+use crate::{Point3, Vector3};
 use num::{FromPrimitive, Integer};
 use obj::raw::object::Polygon;
 use obj::*;
@@ -21,24 +21,24 @@ use crate::ray::Ray;
 pub type TupleVec = (f32, f32, f32);
 
 /// Convert a `TupleVec` to a `nalgebra` point.
-pub fn tuple_to_point(tpl: &TupleVec) -> Point3<f32> {
+pub fn tuple_to_point(tpl: &TupleVec) -> Point3 {
     Point3::new(tpl.0, tpl.1, tpl.2)
 }
 
 /// Convert a `TupleVec` to a `nalgebra` vector.
-pub fn tuple_to_vector(tpl: &TupleVec) -> Vector3<f32> {
+pub fn tuple_to_vector(tpl: &TupleVec) -> Vector3 {
     Vector3::new(tpl.0, tpl.1, tpl.2)
 }
 
 /// Define some `Bounded` structure.
 pub struct UnitBox {
     pub id: i32,
-    pub pos: Point3<f32>,
+    pub pos: Point3,
     node_index: usize,
 }
 
 impl UnitBox {
-    pub fn new(id: i32, pos: Point3<f32>) -> UnitBox {
+    pub fn new(id: i32, pos: Point3) -> UnitBox {
         UnitBox {
             id: id,
             pos: pos,
@@ -87,8 +87,8 @@ pub fn build_some_bh<BH: BoundingHierarchy>() -> (Vec<UnitBox>, BH) {
 /// Given a ray, a bounding hierarchy, the complete list of shapes in the scene and a list of
 /// expected hits, verifies, whether the ray hits only the expected shapes.
 fn traverse_and_verify<BH: BoundingHierarchy>(
-    ray_origin: Point3<f32>,
-    ray_direction: Vector3<f32>,
+    ray_origin: Point3,
+    ray_direction: Vector3,
     all_shapes: &Vec<UnitBox>,
     bh: &BH,
     expected_shapes: &HashSet<i32>,
@@ -147,15 +147,15 @@ pub fn traverse_some_bh<BH: BoundingHierarchy>() {
 /// A triangle struct. Instance of a more complex `Bounded` primitive.
 #[derive(Debug)]
 pub struct Triangle {
-    pub a: Point3<f32>,
-    pub b: Point3<f32>,
-    pub c: Point3<f32>,
+    pub a: Point3,
+    pub b: Point3,
+    pub c: Point3,
     aabb: AABB,
     node_index: usize,
 }
 
 impl Triangle {
-    pub fn new(a: Point3<f32>, b: Point3<f32>, c: Point3<f32>) -> Triangle {
+    pub fn new(a: Point3, b: Point3, c: Point3) -> Triangle {
         Triangle {
             a: a,
             b: b,
@@ -227,7 +227,7 @@ impl<I: FromPrimitive + Integer> FromRawVertex<I> for Triangle {
 }
 
 /// Creates a unit size cube centered at `pos` and pushes the triangles to `shapes`.
-fn push_cube(pos: Point3<f32>, shapes: &mut Vec<Triangle>) {
+fn push_cube(pos: Point3, shapes: &mut Vec<Triangle>) {
     let top_front_right = pos + Vector3::new(0.5, 0.5, -0.5);
     let top_back_right = pos + Vector3::new(0.5, 0.5, 0.5);
     let top_back_left = pos + Vector3::new(-0.5, 0.5, 0.5);
@@ -315,7 +315,7 @@ pub fn next_point3_raw(seed: &mut u64) -> (i32, i32, i32) {
 }
 
 /// Generates a new `Point3`, which will lie inside the given `aabb`. Mutates the seed.
-pub fn next_point3(seed: &mut u64, aabb: &AABB) -> Point3<f32> {
+pub fn next_point3(seed: &mut u64, aabb: &AABB) -> Point3 {
     let (a, b, c) = next_point3_raw(seed);
     use std::i32;
     let float_vector = Vector3::new(
@@ -403,11 +403,11 @@ pub fn randomly_transform_scene(
 
     for index in &indices {
         let aabb = triangles[*index].aabb();
-        let min_move_bound = bounds.min - aabb.min.coords;
-        let max_move_bound = bounds.max - aabb.max.coords;
+        let min_move_bound = bounds.min - aabb.min;
+        let max_move_bound = bounds.max - aabb.max;
         let movement_bounds = AABB::with_bounds(min_move_bound, max_move_bound);
 
-        let mut random_offset = next_point3(seed, &movement_bounds).coords;
+        let mut random_offset = next_point3(seed, &movement_bounds);
         random_offset.x = max_offset.min((-max_offset).max(random_offset.x));
         random_offset.y = max_offset.min((-max_offset).max(random_offset.y));
         random_offset.z = max_offset.min((-max_offset).max(random_offset.z));
@@ -431,7 +431,7 @@ pub fn randomly_transform_scene(
 #[cfg(feature = "bench")]
 pub fn create_ray(seed: &mut u64, bounds: &AABB) -> Ray {
     let origin = next_point3(seed, bounds);
-    let direction = next_point3(seed, bounds).coords;
+    let direction = next_point3(seed, bounds);
     Ray::new(origin, direction)
 }
 


### PR DESCRIPTION
Ported the use of math types to glam. Mostly very straightforward. It was 99% search & replace. Tests and benchmarks pass.

I've opted to type alias `glam::Vec3` directly in lib.rs for visibility and simplicity. So now we have `bvh::Point3` and `bvh::Vector3` which are used everywhere.

Changes of interest:
`lib.rs` for the above type aliases
`aabb.relative_eq` (no longer using approx, because it's not implemented on Vec3)
`ray.sign` (split out the Vector3<usize> into 3 variables)

Resolves #38