### PR TITLE
Add blanket impls for `Bounded`, `BHShape`, `BoundingHierarchy`

### DIFF
--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -60,6 +60,24 @@ pub trait Bounded {
     fn aabb(&self) -> AABB;
 }
 
+impl<T: Bounded> Bounded for &T {
+    fn aabb(&self) -> AABB {
+        T::aabb(self)
+    }
+}
+
+impl<T: Bounded> Bounded for &mut T {
+    fn aabb(&self) -> AABB {
+        T::aabb(self)
+    }
+}
+
+impl<T: Bounded> Bounded for Box<T> {
+    fn aabb(&self) -> AABB {
+        T::aabb(self)
+    }
+}
+
 impl AABB {
     /// Creates a new [`AABB`] with the given bounds.
     ///

--- a/src/bounding_hierarchy.rs
+++ b/src/bounding_hierarchy.rs
@@ -23,6 +23,26 @@ pub trait BHShape: Bounded {
     fn bh_node_index(&self) -> usize;
 }
 
+impl<T: BHShape> BHShape for &mut T {
+    fn set_bh_node_index(&mut self, idx: usize) {
+        T::set_bh_node_index(self, idx)
+    }
+
+    fn bh_node_index(&self) -> usize {
+        T::bh_node_index(self)
+    }
+}
+
+impl<T: BHShape> BHShape for Box<T> {
+    fn set_bh_node_index(&mut self, idx: usize) {
+        T::set_bh_node_index(self, idx)
+    }
+
+    fn bh_node_index(&self) -> usize {
+        T::bh_node_index(self)
+    }
+}
+
 /// This trait defines an acceleration structure with space partitioning.
 /// This structure is used to efficiently compute ray-scene intersections.
 pub trait BoundingHierarchy {
@@ -170,4 +190,14 @@ pub trait BoundingHierarchy {
     /// [`BoundingHierarchy`]: trait.BoundingHierarchy.html
     ///
     fn pretty_print(&self) {}
+}
+
+impl<T: BoundingHierarchy> BoundingHierarchy for Box<T> {
+    fn build<Shape: BHShape>(shapes: &mut [Shape]) -> Self {
+        Box::new(T::build(shapes))
+    }
+
+    fn traverse<'a, Shape: BHShape>(&'a self, ray: &Ray, shapes: &'a [Shape]) -> Vec<&Shape> {
+        T::traverse(self, ray, shapes)
+    }
 }


### PR DESCRIPTION
These implementations are useful to have for most traits generally, but in particular I was running into issues trying to call methods from `Bounded` where I had a `Vec<&T>` where `T: Bounded` (for example).

I've included blanket impls of:

- `Bounded` for `&T`, `&mut T` and `Box<T>`
- `BHShape` for `&mut T` and `Box<T>` (not `&T` because `set_bh_node_index()` takes `&mut self`)
- `BoundingHierarchy` for `Box<T>` (not `&T` or `&mut T` because `build()` is a constructor/needs to return an owned value)