### PR TITLE
Widen lifetime bounds on BVHTraverseIterator

### DIFF
--- a/src/bvh/bvh_impl.rs
+++ b/src/bvh/bvh_impl.rs
@@ -447,11 +447,11 @@ impl BVH {
     /// [`BVH`]: struct.BVH.html
     /// [`AABB`]: ../aabb/struct.AABB.html
     ///
-    pub fn traverse_iterator<'a, Shape: Bounded>(
-        &'a self,
-        ray: &'a Ray,
-        shapes: &'a [Shape],
-    ) -> BVHTraverseIterator<Shape> {
+    pub fn traverse_iterator<'bvh, 'shape, Shape: Bounded>(
+        &'bvh self,
+        ray: &'bvh Ray,
+        shapes: &'shape [Shape],
+    ) -> BVHTraverseIterator<'bvh, 'shape, Shape> {
         BVHTraverseIterator::new(self, ray, shapes)
     }
 

--- a/src/bvh/iter.rs
+++ b/src/bvh/iter.rs
@@ -4,13 +4,13 @@ use crate::ray::Ray;
 
 /// Iterator to traverse a [`BVH`] without memory allocations
 #[allow(clippy::upper_case_acronyms)]
-pub struct BVHTraverseIterator<'a, Shape: Bounded> {
+pub struct BVHTraverseIterator<'bvh, 'shape, Shape: Bounded> {
     /// Reference to the BVH to traverse
-    bvh: &'a BVH,
+    bvh: &'bvh BVH,
     /// Reference to the input ray
-    ray: &'a Ray,
+    ray: &'bvh Ray,
     /// Reference to the input shapes array
-    shapes: &'a [Shape],
+    shapes: &'shape [Shape],
     /// Traversal stack. 4 billion items seems enough?
     stack: [usize; 32],
     /// Position of the iterator in bvh.nodes
@@ -21,9 +21,9 @@ pub struct BVHTraverseIterator<'a, Shape: Bounded> {
     has_node: bool,
 }
 
-impl<'a, Shape: Bounded> BVHTraverseIterator<'a, Shape> {
+impl<'bvh, 'shape, Shape: Bounded> BVHTraverseIterator<'bvh, 'shape, Shape> {
     /// Creates a new `BVHTraverseIterator`
-    pub fn new(bvh: &'a BVH, ray: &'a Ray, shapes: &'a [Shape]) -> Self {
+    pub fn new(bvh: &'bvh BVH, ray: &'bvh Ray, shapes: &'shape [Shape]) -> Self {
         BVHTraverseIterator {
             bvh,
             ray,
@@ -105,10 +105,10 @@ impl<'a, Shape: Bounded> BVHTraverseIterator<'a, Shape> {
     }
 }
 
-impl<'a, Shape: Bounded> Iterator for BVHTraverseIterator<'a, Shape> {
-    type Item = &'a Shape;
+impl<'bvh, 'shape, Shape: Bounded> Iterator for BVHTraverseIterator<'bvh, 'shape, Shape> {
+    type Item = &'shape Shape;
 
-    fn next(&mut self) -> Option<&'a Shape> {
+    fn next(&mut self) -> Option<&'shape Shape> {
         loop {
             if self.is_stack_empty() && !self.has_node {
                 // Completed traversal.


### PR DESCRIPTION
This fixes an issue I was having where an enclosing function couldn't return data referencing the shape returned by the BVHTraverseIterator.