### PR TITLE
Implement ordered traverse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 Cargo.lock
 proptest-regressions
+.idea/

--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -454,8 +454,7 @@ impl<T: BHValue, const D: usize> Aabb<T, D> {
     /// [`Aabb`]: struct.Aabb.html
     ///
     #[inline]
-    pub fn half_size(&self) -> SVector<T, D>
-    {
+    pub fn half_size(&self) -> SVector<T, D> {
         self.size() * T::from_f32(0.5).unwrap()
     }
 

--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -455,8 +455,6 @@ impl<T: BHValue, const D: usize> Aabb<T, D> {
     ///
     #[inline]
     pub fn half_size(&self) -> SVector<T, D>
-    where
-        T: Scalar + Copy + ClosedSub + ClosedAdd + ClosedMul + FromPrimitive + RealField,
     {
         self.size() * T::from_f32(0.5).unwrap()
     }

--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -438,6 +438,29 @@ impl<T: BHValue, const D: usize> Aabb<T, D> {
         self.max - self.min
     }
 
+    /// Returns the half size of this [`Aabb`] in all three dimensions.
+    /// This can be interpreted as the distance from the center to the edges
+    ///
+    /// # Examples
+    /// ```
+    /// use bvh::aabb::Aabb;
+    /// use nalgebra::Point3;
+    ///
+    /// let aabb = Aabb::with_bounds(Point3::new(0.0,0.0,0.0), Point3::new(2.0,2.0,2.0));
+    /// let half_size = aabb.half_size();
+    /// assert!(half_size.x == 1.0 && half_size.y == 1.0 && half_size.z == 1.0);
+    /// ```
+    ///
+    /// [`Aabb`]: struct.Aabb.html
+    ///
+    #[inline]
+    pub fn half_size(&self) -> SVector<T, D>
+    where
+        T: Scalar + Copy + ClosedSub + ClosedAdd + ClosedMul + FromPrimitive + RealField,
+    {
+        self.size() * T::from_f32(0.5).unwrap()
+    }
+
     /// Returns the center [`Point3`] of the [`Aabb`].
     ///
     /// # Examples

--- a/src/bvh/bvh_impl.rs
+++ b/src/bvh/bvh_impl.rs
@@ -329,7 +329,7 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
                 let shape_aabb = shapes[shape_index].aabb();
                 assert!(
                     expected_outer_aabb.approx_contains_aabb_eps(&shape_aabb, T::epsilon()),
-                    "{}", "Shape's Aabb lies outside the expected bounds.\n\tBounds: {expected_outer_aabb}\n\tShape: {shape_aabb}"
+                    "Shape's Aabb lies outside the expected bounds.\n\tBounds: {expected_outer_aabb}\n\tShape: {shape_aabb}"
                 );
             }
         }

--- a/src/bvh/bvh_impl.rs
+++ b/src/bvh/bvh_impl.rs
@@ -12,7 +12,7 @@ use crate::utils::joint_aabb_of_shapes;
 
 use std::mem::MaybeUninit;
 
-use super::{BvhNode, BvhNodeBuildArgs, ShapeIndex, Shapes};
+use super::{BvhNode, BvhNodeBuildArgs, DistanceTraverseIterator, ShapeIndex, Shapes};
 
 /// The [`Bvh`] data structure. Contains the list of [`BvhNode`]s.
 ///
@@ -136,8 +136,6 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
         ray: &'bvh Ray<T, D>,
         shapes: &'shape [Shape],
     ) -> DistanceTraverseIterator<'bvh, 'shape, T, D, Shape, true>
-    where
-        T: RealField,
     {
         DistanceTraverseIterator::new(self, ray, shapes)
     }
@@ -154,8 +152,6 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
         ray: &'bvh Ray<T, D>,
         shapes: &'shape [Shape],
     ) -> DistanceTraverseIterator<'bvh, 'shape, T, D, Shape, false>
-    where
-        T: RealField,
     {
         DistanceTraverseIterator::new(self, ray, shapes)
     }

--- a/src/bvh/bvh_impl.rs
+++ b/src/bvh/bvh_impl.rs
@@ -92,7 +92,7 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
     }
 
     /// Traverses the [`Bvh`].
-    /// Returns a subset of `shapes`, in which the [`Aabb`]s of the elements were hit by `ray`.
+    /// Returns a subset of `shapes`, in which the [`Aabb`]s of the elements were hit by [`Ray`].
     ///
     /// [`Bvh`]: struct.Bvh.html
     /// [`Aabb`]: ../aabb/struct.Aabb.html
@@ -111,7 +111,7 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
     }
 
     /// Creates a [`BvhTraverseIterator`] to traverse the [`Bvh`].
-    /// Returns a subset of `shapes`, in which the [`Aabb`]s of the elements were hit by `ray`.
+    /// Returns a subset of `shapes`, in which the [`Aabb`]s of the elements were hit by [`Ray`].
     ///
     /// [`Bvh`]: struct.Bvh.html
     /// [`Aabb`]: ../aabb/struct.Aabb.html
@@ -122,6 +122,42 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
         shapes: &'shape [Shape],
     ) -> BvhTraverseIterator<'bvh, 'shape, T, D, Shape> {
         BvhTraverseIterator::new(self, ray, shapes)
+    }
+
+    /// Creates a [`DistanceTraverseIterator`] to traverse the [`Bvh`].
+    /// Returns a subset of [`shape`], in which the [`Aabb`]s of the elements were hit by [`Ray`].
+    /// Return in order from nearest to farthest for ray.
+    ///
+    /// [`Bvh`]: struct.Bvh.html
+    /// [`Aabb`]: ../aabb/struct.AABB.html
+    ///
+    pub fn nearest_traverse_iterator<'bvh, 'shape, Shape: Bounded<T, D>>(
+        &'bvh self,
+        ray: &'bvh Ray<T, D>,
+        shapes: &'shape [Shape],
+    ) -> DistanceTraverseIterator<'bvh, 'shape, T, D, Shape, true>
+    where
+        T: RealField,
+    {
+        DistanceTraverseIterator::new(self, ray, shapes)
+    }
+
+    /// Creates a [`DistanceTraverseIterator`] to traverse the [`Bvh`].
+    /// Returns a subset of [`Shape`], in which the [`Aabb`]s of the elements were hit by [`Ray`].
+    /// Return in order from nearest to farthest for ray.
+    ///
+    /// [`Bvh`]: struct.Bvh.html
+    /// [`Aabb`]: ../aabb/struct.AABB.html
+    ///
+    pub fn farthest_traverse_iterator<'bvh, 'shape, Shape: Bounded<T, D>>(
+        &'bvh self,
+        ray: &'bvh Ray<T, D>,
+        shapes: &'shape [Shape],
+    ) -> DistanceTraverseIterator<'bvh, 'shape, T, D, Shape, false>
+    where
+        T: RealField,
+    {
+        DistanceTraverseIterator::new(self, ray, shapes)
     }
 
     /// Prints the [`Bvh`] in a tree-like visualization.
@@ -251,8 +287,7 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
         let parent = node.parent();
         assert_eq!(
             expected_parent_index, parent,
-            "Wrong parent index. Expected: {}; Actual: {}",
-            expected_parent_index, parent
+            "Wrong parent index. Expected: {expected_parent_index}; Actual: {parent}"
         );
 
         match *node {
@@ -298,9 +333,7 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
                 let shape_aabb = shapes[shape_index].aabb();
                 assert!(
                     expected_outer_aabb.approx_contains_aabb_eps(&shape_aabb, T::epsilon()),
-                    "Shape's Aabb lies outside the expected bounds.\n\tBounds: {}\n\tShape: {}",
-                    expected_outer_aabb,
-                    shape_aabb
+                    "{}", "Shape's Aabb lies outside the expected bounds.\n\tBounds: {expected_outer_aabb}\n\tShape: {shape_aabb}"
                 );
             }
         }

--- a/src/bvh/bvh_impl.rs
+++ b/src/bvh/bvh_impl.rs
@@ -135,8 +135,7 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
         &'bvh self,
         ray: &'bvh Ray<T, D>,
         shapes: &'shape [Shape],
-    ) -> DistanceTraverseIterator<'bvh, 'shape, T, D, Shape, true>
-    {
+    ) -> DistanceTraverseIterator<'bvh, 'shape, T, D, Shape, true> {
         DistanceTraverseIterator::new(self, ray, shapes)
     }
 
@@ -151,8 +150,7 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
         &'bvh self,
         ray: &'bvh Ray<T, D>,
         shapes: &'shape [Shape],
-    ) -> DistanceTraverseIterator<'bvh, 'shape, T, D, Shape, false>
-    {
+    ) -> DistanceTraverseIterator<'bvh, 'shape, T, D, Shape, false> {
         DistanceTraverseIterator::new(self, ray, shapes)
     }
 

--- a/src/bvh/distance_traverse.rs
+++ b/src/bvh/distance_traverse.rs
@@ -1,6 +1,5 @@
-use nalgebra::{RealField, Scalar};
-
 use crate::aabb::Bounded;
+use crate::bounding_hierarchy::BHValue;
 use crate::bvh::{Bvh, BvhNode};
 use crate::ray::Ray;
 
@@ -16,7 +15,7 @@ enum RestChild {
 pub struct DistanceTraverseIterator<
     'bvh,
     'shape,
-    T: Scalar + Copy,
+    T: BHValue,
     const D: usize,
     Shape: Bounded<T, D>,
     const ASCENDING: bool,
@@ -40,7 +39,7 @@ pub struct DistanceTraverseIterator<
 impl<'bvh, 'shape, T, const D: usize, Shape: Bounded<T, D>, const ASCENDING: bool>
     DistanceTraverseIterator<'bvh, 'shape, T, D, Shape, ASCENDING>
 where
-    T: Scalar + Copy + Scalar + RealField,
+    T: BHValue,
 {
     /// Creates a new [`DistanceTraverseIterator `]
     pub fn new(bvh: &'bvh Bvh<T, D>, ray: &'bvh Ray<T, D>, shapes: &'shape [Shape]) -> Self {
@@ -219,7 +218,7 @@ where
 impl<'bvh, 'shape, T, const D: usize, Shape: Bounded<T, D>, const ASCENDING: bool> Iterator
     for DistanceTraverseIterator<'bvh, 'shape, T, D, Shape, ASCENDING>
 where
-    T: Scalar + Copy + RealField,
+    T: BHValue,
 {
     type Item = &'shape Shape;
 

--- a/src/bvh/distance_traverse.rs
+++ b/src/bvh/distance_traverse.rs
@@ -1,0 +1,357 @@
+use nalgebra::{RealField, Scalar};
+
+use crate::aabb::Bounded;
+use crate::bvh::{Bvh, BvhNode};
+use crate::ray::Ray;
+
+#[derive(Debug, Clone, Copy)]
+enum RestChild {
+    Left,
+    Right,
+    None,
+}
+
+/// Iterator to traverse a [`Bvh`] in order from nearest [`Aabb`] to farthest for [`Ray`],
+/// without memory allocations
+pub struct DistanceTraverseIterator<
+    'bvh,
+    'shape,
+    T: Scalar + Copy,
+    const D: usize,
+    Shape: Bounded<T, D>,
+    const ASCENDING: bool,
+> {
+    /// Reference to the Bvh to traverse
+    bvh: &'bvh Bvh<T, D>,
+    /// Reference to the input ray
+    ray: &'bvh Ray<T, D>,
+    /// Reference to the input shapes array
+    shapes: &'shape [Shape],
+    /// Traversal stack. 4 billion items seems enough?
+    stack: [(usize, RestChild); 32],
+    /// Position of the iterator in bvh.nodes
+    node_index: usize,
+    /// Size of the traversal stack
+    stack_size: usize,
+    /// Whether or not we have a valid node (or leaf)
+    has_node: bool,
+}
+
+impl<'bvh, 'shape, T, const D: usize, Shape: Bounded<T, D>, const ASCENDING: bool>
+    DistanceTraverseIterator<'bvh, 'shape, T, D, Shape, ASCENDING>
+where
+    T: Scalar + Copy + Scalar + RealField,
+{
+    /// Creates a new [`DistanceTraverseIterator `]
+    pub fn new(bvh: &'bvh Bvh<T, D>, ray: &'bvh Ray<T, D>, shapes: &'shape [Shape]) -> Self {
+        DistanceTraverseIterator {
+            bvh,
+            ray,
+            shapes,
+            stack: [(0, RestChild::None); 32],
+            node_index: 0,
+            stack_size: 0,
+            has_node: true,
+        }
+    }
+
+    /// Return `true` if stack is empty.
+    fn is_stack_empty(&self) -> bool {
+        self.stack_size == 0
+    }
+
+    /// Push node onto stack.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `stack[stack_size]` is out of bounds.
+    fn stack_push(&mut self, nodes: (usize, RestChild)) {
+        self.stack[self.stack_size] = nodes;
+        self.stack_size += 1;
+    }
+
+    /// Pop the stack and return the node.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `stack_size` underflows.
+    fn stack_pop(&mut self) -> (usize, RestChild) {
+        self.stack_size -= 1;
+        self.stack[self.stack_size]
+    }
+
+    /// Attempt to move to the child node that is closest to the ray, relative to the current node.
+    /// If it is a leaf, or the [`Ray`] does not intersect the any node [`Aabb`], `has_node` will become `false`.
+    fn move_nearest(&mut self) -> (usize, RestChild) {
+        let current_node_index = self.node_index;
+        match self.bvh.nodes[current_node_index] {
+            BvhNode::Node {
+                child_l_index,
+                ref child_l_aabb,
+                child_r_index,
+                ref child_r_aabb,
+                ..
+            } => {
+                let (left_dist, _) = self.ray.intersection_slice_for_aabb(child_l_aabb);
+                let (right_dist, _) = self.ray.intersection_slice_for_aabb(child_r_aabb);
+
+                if left_dist < T::zero() {
+                    if right_dist < T::zero() {
+                        // no intersections with any children
+                        self.has_node = false;
+                        (current_node_index, RestChild::None)
+                    } else {
+                        // has intersection only with right child
+                        self.has_node = true;
+                        self.node_index = child_r_index;
+                        let rest_child = RestChild::None;
+                        (current_node_index, rest_child)
+                    }
+                } else if right_dist < T::zero() {
+                    // has intersection only with left child
+                    self.has_node = true;
+                    self.node_index = child_l_index;
+                    let rest_child = RestChild::None;
+                    (current_node_index, rest_child)
+                } else if left_dist > right_dist {
+                    // right is closer than left
+                    self.has_node = true;
+                    self.node_index = child_r_index;
+                    let rest_child = RestChild::Left;
+                    return (current_node_index, rest_child);
+                } else {
+                    // left is closer than right
+                    self.has_node = true;
+                    self.node_index = child_l_index;
+                    let rest_child = RestChild::Right;
+                    return (current_node_index, rest_child);
+                }
+            }
+            BvhNode::Leaf { .. } => {
+                self.has_node = false;
+                (current_node_index, RestChild::None)
+            }
+        }
+    }
+
+    /// Attempt to move to the child node that is the farthest from the ray, relative to the current node.
+    /// If it is a leaf, or the [`Ray`] does not intersect the node [`Aabb`], `has_node` will become `false`.
+    fn move_furthest(&mut self) -> (usize, RestChild) {
+        let current_node_index = self.node_index;
+        match self.bvh.nodes[current_node_index] {
+            BvhNode::Node {
+                child_l_index,
+                ref child_l_aabb,
+                child_r_index,
+                ref child_r_aabb,
+                ..
+            } => {
+                let (_, left_dist) = self.ray.intersection_slice_for_aabb(child_l_aabb);
+                let (_, right_dist) = self.ray.intersection_slice_for_aabb(child_r_aabb);
+
+                if left_dist < T::zero() {
+                    if right_dist < T::zero() {
+                        // no intersections with any children
+                        self.has_node = false;
+                        (current_node_index, RestChild::None)
+                    } else {
+                        // has intersection only with right child
+                        self.has_node = true;
+                        self.node_index = child_r_index;
+                        let rest_child = RestChild::None;
+                        (current_node_index, rest_child)
+                    }
+                } else if right_dist < T::zero() {
+                    // has intersection only with left child
+                    self.has_node = true;
+                    self.node_index = child_l_index;
+                    let rest_child = RestChild::None;
+                    (current_node_index, rest_child)
+                } else if left_dist < right_dist {
+                    // right is farther than left
+                    self.has_node = true;
+                    self.node_index = child_r_index;
+                    let rest_child = RestChild::Left;
+                    return (current_node_index, rest_child);
+                } else {
+                    // left is farther than right
+                    self.has_node = true;
+                    self.node_index = child_l_index;
+                    let rest_child = RestChild::Right;
+                    return (current_node_index, rest_child);
+                }
+            }
+            BvhNode::Leaf { .. } => {
+                self.has_node = false;
+                (current_node_index, RestChild::None)
+            }
+        }
+    }
+
+    /// Attempt to move to the rest not visited child of the current node.
+    /// If it is a leaf, or the [`Ray`] does not intersect the node [`Aabb`], `has_node` will become `false`.
+    fn move_rest(&mut self, rest_child: RestChild) {
+        match self.bvh.nodes[self.node_index] {
+            BvhNode::Node {
+                child_r_index,
+                child_l_index,
+                ..
+            } => match rest_child {
+                RestChild::Left => {
+                    self.node_index = child_l_index;
+                    self.has_node = true;
+                }
+                RestChild::Right => {
+                    self.node_index = child_r_index;
+                    self.has_node = true;
+                }
+                RestChild::None => {
+                    self.has_node = false;
+                }
+            },
+            BvhNode::Leaf { .. } => {
+                self.has_node = false;
+            }
+        }
+    }
+}
+
+impl<'bvh, 'shape, T, const D: usize, Shape: Bounded<T, D>, const ASCENDING: bool> Iterator
+    for DistanceTraverseIterator<'bvh, 'shape, T, D, Shape, ASCENDING>
+where
+    T: Scalar + Copy + RealField,
+{
+    type Item = &'shape Shape;
+
+    fn next(&mut self) -> Option<&'shape Shape> {
+        loop {
+            if self.is_stack_empty() && !self.has_node {
+                // Completed traversal.
+                break;
+            }
+
+            if self.has_node {
+                // If we have any node, attempt to move to its nearest child.
+                let stack_info = if ASCENDING {
+                    self.move_nearest()
+                } else {
+                    self.move_furthest()
+                };
+                // Save current node and farthest child
+                self.stack_push(stack_info)
+            } else {
+                // Go back up the stack and see if a node or leaf was pushed.
+                let (node_index, rest_child) = self.stack_pop();
+                self.node_index = node_index;
+                match self.bvh.nodes[self.node_index] {
+                    BvhNode::Node { .. } => {
+                        // If a node was pushed, now move to `unvisited` rest child, next in order.
+                        self.move_rest(rest_child);
+                    }
+                    BvhNode::Leaf { shape_index, .. } => {
+                        // We previously pushed a leaf node. This is the "visit" of the in-order traverse.
+                        // Next time we call `next()` we try to pop the stack again.
+                        return Some(&self.shapes[shape_index]);
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::aabb::Bounded;
+    use crate::bvh::Bvh;
+    use crate::ray::Ray;
+    use crate::testbase::{generate_aligned_boxes, TBvh3, TPoint3, TVector3, UnitBox};
+    use std::collections::HashSet;
+
+    /// Create a `Bvh` for a fixed scene structure.
+    pub fn build_some_bvh() -> (Vec<UnitBox>, TBvh3) {
+        let mut boxes = generate_aligned_boxes();
+        let bvh = Bvh::build(&mut boxes);
+        (boxes, bvh)
+    }
+
+    fn traverse_distance_and_verify_order(
+        ray_origin: TPoint3,
+        ray_direction: TVector3,
+        all_shapes: &[UnitBox],
+        bvh: &TBvh3,
+        expected_shapes: &HashSet<i32>,
+    ) {
+        let ray = Ray::new(ray_origin, ray_direction);
+        let near_it = bvh.nearest_traverse_iterator(&ray, all_shapes);
+        let far_it = bvh.farthest_traverse_iterator(&ray, all_shapes);
+
+        let mut count = 0;
+        let mut prev_near_dist = -1.0;
+        let mut prev_far_dist = f32::INFINITY;
+
+        for (near_shape, far_shape) in near_it.zip(far_it) {
+            let (intersect_near_dist, _) = ray.intersection_slice_for_aabb(&near_shape.aabb());
+            let (intersect_far_dist, _) = ray.intersection_slice_for_aabb(&far_shape.aabb());
+
+            assert!(expected_shapes.contains(&near_shape.id));
+            assert!(expected_shapes.contains(&far_shape.id));
+            assert!(prev_near_dist <= intersect_near_dist);
+            assert!(prev_far_dist >= intersect_far_dist);
+
+            count += 1;
+            prev_near_dist = intersect_near_dist;
+            prev_far_dist = intersect_far_dist;
+        }
+        assert_eq!(expected_shapes.len(), count);
+    }
+
+    /// Perform some fixed intersection tests on BH structures.
+    pub fn traverse_some_bvh() {
+        let (all_shapes, bvh) = build_some_bvh();
+
+        {
+            // Define a ray which traverses the x-axis from afar.
+            let origin = TPoint3::new(-1000.0, 0.0, 0.0);
+            let direction = TVector3::new(1.0, 0.0, 0.0);
+            let mut expected_shapes = HashSet::new();
+
+            // It should hit everything.
+            for id in -10..11 {
+                expected_shapes.insert(id);
+            }
+            traverse_distance_and_verify_order(
+                origin,
+                direction,
+                &all_shapes,
+                &bvh,
+                &expected_shapes,
+            );
+        }
+
+        {
+            // Define a ray which intersects the x-axis diagonally.
+            let origin = TPoint3::new(6.0, 0.5, 0.0);
+            let direction = TVector3::new(-2.0, -1.0, 0.0);
+
+            // It should hit exactly three boxes.
+            let mut expected_shapes = HashSet::new();
+            expected_shapes.insert(4);
+            expected_shapes.insert(5);
+            expected_shapes.insert(6);
+            traverse_distance_and_verify_order(
+                origin,
+                direction,
+                &all_shapes,
+                &bvh,
+                &expected_shapes,
+            );
+        }
+    }
+
+    #[test]
+    /// Runs some primitive tests for intersections of a ray with a fixed scene given as a Bvh.
+    fn test_traverse_bvh() {
+        traverse_some_bvh();
+    }
+}

--- a/src/bvh/mod.rs
+++ b/src/bvh/mod.rs
@@ -5,9 +5,11 @@
 
 mod bvh_impl;
 mod bvh_node;
+mod distance_traverse;
 mod iter;
 mod optimization;
 
 pub use self::bvh_impl::*;
 pub use self::bvh_node::*;
+pub use self::distance_traverse::*;
 pub use self::iter::*;

--- a/src/ray/ray_impl.rs
+++ b/src/ray/ray_impl.rs
@@ -4,6 +4,7 @@
 use crate::{aabb::Aabb, bounding_hierarchy::BHValue};
 use nalgebra::{ClosedAdd, ClosedMul, ClosedSub, ComplexField, Point, SVector, SimdPartialOrd};
 use num::{Float, One, Zero};
+use crate::utils::{fast_max, fast_min};
 
 use super::intersect_default::RayIntersection;
 
@@ -112,17 +113,7 @@ impl<T: BHValue, const D: usize> Ray<T, D> {
     /// If there are no intersections, it returns negative one for both distances
     pub fn intersection_slice_for_aabb(&self, aabb: &Aabb<T, D>) -> (T, T)
     where
-        T: ClosedSub
-            + ClosedMul
-            + ClosedAdd
-            + Signed
-            + Zero
-            + PartialOrd
-            + SimdPartialOrd
-            + FromPrimitive
-            + Copy
-            + Scalar
-            + RealField,
+        T: BHValue,
     {
         // https://iquilezles.org/articles/intersectors/
         let mut n = self.origin.coords - aabb.center().coords;

--- a/src/ray/ray_impl.rs
+++ b/src/ray/ray_impl.rs
@@ -1,10 +1,10 @@
 //! This module defines a Ray structure and intersection algorithms
 //! for axis aligned bounding boxes and triangles.
 
+use crate::utils::{fast_max, fast_min};
 use crate::{aabb::Aabb, bounding_hierarchy::BHValue};
 use nalgebra::{ClosedAdd, ClosedMul, ClosedSub, ComplexField, Point, SVector, SimdPartialOrd};
 use num::{Float, One, Zero};
-use crate::utils::{fast_max, fast_min};
 
 use super::intersect_default::RayIntersection;
 

--- a/src/ray/ray_impl.rs
+++ b/src/ray/ray_impl.rs
@@ -254,6 +254,40 @@ mod tests {
             assert!(!ray.intersects_aabb(&aabb) || aabb.contains(&ray.origin));
         }
 
+        // Test whether a `Ray` which points at the center of an `Aabb` takes intersection slice.
+        #[test]
+        fn test_ray_slice_at_aabb_center(data in (tuplevec_small_strategy(),
+                                                   tuplevec_small_strategy(),
+                                                   tuplevec_small_strategy())) {
+            let (ray, aabb) = gen_ray_to_aabb(data);
+            let (start_dist, end_dist) = ray.intersection_slice_for_aabb(&aabb);
+            assert!(start_dist < end_dist);
+            assert!(start_dist >= 0.0);
+        }
+
+        // Test whether a `Ray` which points away from the center of an `Aabb`
+        // cannot take intersection slice of it, unless its origin is inside the `Aabb`.
+        #[test]
+        fn test_ray_slice_from_aabb_center(data in (tuplevec_small_strategy(),
+                                                     tuplevec_small_strategy(),
+                                                     tuplevec_small_strategy())) {
+            let (mut ray, aabb) = gen_ray_to_aabb(data);
+
+            // Invert the direction of the ray
+            ray.direction = -ray.direction;
+            ray.inv_direction = -ray.inv_direction;
+
+            let (start_dist, end_dist) = ray.intersection_slice_for_aabb(&aabb);
+            if aabb.contains(&ray.origin) {
+                // ray inside of aabb
+                assert!(start_dist < end_dist);
+                assert!(start_dist >= 0.0);
+            } else {
+                // ray outside of aabb and doesn't intersect it
+                assert!((start_dist, end_dist) == (-1.0, -1.0));
+            }
+        }
+
         // Test whether a `Ray` which points at the center of a triangle
         // intersects it, unless it sees the back face, which is culled.
         #[test]


### PR DESCRIPTION
Hi. I have implemented a new iterator to traverse.
It traverses the tree from the nearest AABB to the farthest for the passed ray.
