### PR TITLE
Add nearest shape to point queries for bvh

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,6 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 arbitrary = { version = "1.4.1", features = ["derive"] }
+approx = "0.5"
 libfuzzer-sys = "0.4"
 nalgebra = "0.33"
 ordered-float = { version = "4.6.0", features = ["arbitrary"] }

--- a/src/aabb/aabb_impl.rs
+++ b/src/aabb/aabb_impl.rs
@@ -594,6 +594,53 @@ impl<T: BHValue, const D: usize> Aabb<T, D> {
     pub fn largest_axis(&self) -> usize {
         self.size().imax()
     }
+
+    /// Returns the minimum and maximum distances to the [`Aabb`].
+    /// The minimum distance is the distance to the closest point on the box,
+    /// 0 if the point is inside the box.
+    /// The maximum distance is the distance to the furthest point in the box.
+    ///
+    /// # Examples
+    /// ```
+    /// use bvh::aabb::Aabb;
+    /// use nalgebra::Point3;
+    ///
+    /// let min = Point3::new(0.0,0.0,0.0);
+    /// let max = Point3::new(10.0,10.0,10.0);
+    ///
+    /// let aabb = Aabb::with_bounds(min, max);
+    /// let query = Point3::new(20.0, 0.0, 0.0);
+    /// let (min_dist, max_dist) = aabb.get_min_max_distances(&query);
+    /// assert!(min_dist == 10.0);
+    /// assert!(max_dist == (10.0_f32*10.0 + 10.0*10.0 + 20.0*20.0).sqrt());
+    /// ```
+    ///
+    /// [`Aabb`]: struct.Aabb.html
+    ///
+    pub fn get_min_max_distances(&self, point: &Point<T, D>) -> (T, T) {
+        let half_size = self.size() * T::from_f32(0.5).unwrap();
+        let center = self.center();
+
+        let delta = point - center;
+
+        // See <https://iquilezles.org/articles/distfunctions/>
+        let q = delta.abs() - half_size;
+        let outside_vec = q.map(|x| x.max(T::zero()));
+        let min_dist = outside_vec.dot(&outside_vec).sqrt(); // norm without requiring ComplexField.
+
+        // The signum helps to determine the furthest point
+        let signum = delta
+            // Invert the signum to get the furthest vertex
+            .map(|x| -x.signum())
+            // Make sure we're always on a vertex and not on a face if the point is aligned with the box
+            .map(|x| if x != T::zero() { x } else { T::one() });
+
+        let furthest = center + signum.component_mul(&half_size);
+        let furthest_delta = point - furthest;
+        let max_dist = furthest_delta.dot(&furthest_delta).sqrt();
+
+        (min_dist, max_dist)
+    }
 }
 
 /// Default instance for [`Aabb`]s. Returns an [`Aabb`] which is [`empty()`].

--- a/src/aabb/aabb_impl.rs
+++ b/src/aabb/aabb_impl.rs
@@ -619,7 +619,7 @@ impl<T: BHValue, const D: usize> Aabb<T, D> {
     ///
     pub fn get_min_max_distances(&self, point: &Point<T, D>) -> (T, T) {
         let half_size = self.size() * T::from_f32(0.5).unwrap();
-        let center = self.center();
+        let center = self.min + half_size;
 
         let delta = point - center;
 
@@ -631,9 +631,8 @@ impl<T: BHValue, const D: usize> Aabb<T, D> {
         // The signum helps to determine the furthest point
         let signum = delta
             // Invert the signum to get the furthest vertex
-            .map(|x| -x.signum())
-            // Make sure we're always on a vertex and not on a face if the point is aligned with the box
-            .map(|x| if x != T::zero() { x } else { T::one() });
+            // signum never returns 0.0 so we're sure to be on a vertex.
+            .map(|x| -x.signum());
 
         let furthest = center + signum.component_mul(&half_size);
         let furthest_delta = point - furthest;

--- a/src/aabb/aabb_impl.rs
+++ b/src/aabb/aabb_impl.rs
@@ -595,10 +595,9 @@ impl<T: BHValue, const D: usize> Aabb<T, D> {
         self.size().imax()
     }
 
-    /// Returns the minimum and maximum distances to the [`Aabb`].
+    /// Returns the minimum distance squared to the [`Aabb`].
     /// The minimum distance is the distance to the closest point on the box,
-    /// 0 if the point is inside the box.
-    /// The maximum distance is the distance to the furthest point in the box.
+    /// or 0 if the point is inside the box.
     ///
     /// # Examples
     /// ```
@@ -610,15 +609,14 @@ impl<T: BHValue, const D: usize> Aabb<T, D> {
     ///
     /// let aabb = Aabb::with_bounds(min, max);
     /// let query = Point3::new(20.0, 0.0, 0.0);
-    /// let (min_dist, max_dist) = aabb.get_min_max_distances(&query);
-    /// assert!(min_dist == 10.0);
-    /// assert!(max_dist == (10.0_f32*10.0 + 10.0*10.0 + 20.0*20.0).sqrt());
+    /// let min_dist = aabb.get_min_distance_2(query);
+    /// assert_eq!((min_dist as f32).sqrt(), 10.0);
     /// ```
     ///
     /// [`Aabb`]: struct.Aabb.html
     ///
-    pub fn get_min_max_distances(&self, point: &Point<T, D>) -> (T, T) {
-        let half_size = self.size() * T::from_f32(0.5).unwrap();
+    pub fn get_min_distance_2(&self, point: Point<T, D>) -> T {
+        let half_size = self.half_size();
         let center = self.min + half_size;
 
         let delta = point - center;
@@ -626,19 +624,8 @@ impl<T: BHValue, const D: usize> Aabb<T, D> {
         // See <https://iquilezles.org/articles/distfunctions/>
         let q = delta.abs() - half_size;
         let outside_vec = q.map(|x| x.max(T::zero()));
-        let min_dist = outside_vec.dot(&outside_vec).sqrt(); // norm without requiring ComplexField.
 
-        // The signum helps to determine the furthest point
-        let signum = delta
-            // Invert the signum to get the furthest vertex
-            // signum never returns 0.0 so we're sure to be on a vertex.
-            .map(|x| -x.signum());
-
-        let furthest = center + signum.component_mul(&half_size);
-        let furthest_delta = point - furthest;
-        let max_dist = furthest_delta.dot(&furthest_delta).sqrt();
-
-        (min_dist, max_dist)
+        outside_vec.dot(&outside_vec)
     }
 }
 

--- a/src/aabb/aabb_impl.rs
+++ b/src/aabb/aabb_impl.rs
@@ -609,13 +609,13 @@ impl<T: BHValue, const D: usize> Aabb<T, D> {
     ///
     /// let aabb = Aabb::with_bounds(min, max);
     /// let query = Point3::new(20.0, 0.0, 0.0);
-    /// let min_dist = aabb.get_min_distance_2(query);
+    /// let min_dist = aabb.min_distance_squared(query);
     /// assert_eq!((min_dist as f32).sqrt(), 10.0);
     /// ```
     ///
     /// [`Aabb`]: struct.Aabb.html
     ///
-    pub fn get_min_distance_2(&self, point: Point<T, D>) -> T {
+    pub fn min_distance_squared(&self, point: Point<T, D>) -> T {
         let half_size = self.half_size();
         let center = self.min + half_size;
 

--- a/src/bounding_hierarchy.rs
+++ b/src/bounding_hierarchy.rs
@@ -296,7 +296,7 @@ pub trait BoundingHierarchy<T: BHValue, const D: usize> {
     /// #
     /// # impl PointDistance<f32,3> for UnitBox {
     /// #     fn distance_squared(&self, query_point: Point3<f32>) -> f32 {
-    /// #         self.aabb().get_min_distance_2(query_point)
+    /// #         self.aabb().min_distance_squared(query_point)
     /// #    }
     /// }
     /// # fn create_bvh() -> (Bvh<f32,3>, Vec<UnitBox>) {
@@ -311,14 +311,16 @@ pub trait BoundingHierarchy<T: BHValue, const D: usize> {
     ///
     /// let (bvh, shapes) = create_bvh();
     ///
-    /// let query = Point3::new(5.0, 0.0, 2.0);
-    /// let nearest_shape = bvh.nearest_from(query, &shapes);
+    /// let query = Point3::new(5.0, 5.7, 5.3);
+    /// let nearest_shape = bvh.nearest_to(query, &shapes);
+    ///
+    /// # assert_eq!(nearest_shape.unwrap().0.id, 5);
     /// ```
     ///
     /// [`BoundingHierarchy`]: trait.BoundingHierarchy.html
     /// [`Aabb`]: ../aabb/struct.Aabb.html
     ///
-    fn nearest_from<'a, Shape: BHShape<T, D> + PointDistance<T, D>>(
+    fn nearest_to<'a, Shape: BHShape<T, D> + PointDistance<T, D>>(
         &'a self,
         query: Point<T, D>,
         shapes: &'a [Shape],
@@ -344,12 +346,12 @@ impl<T: BHValue, const D: usize, H: BoundingHierarchy<T, D>> BoundingHierarchy<T
         H::traverse(self, query, shapes)
     }
 
-    fn nearest_from<'a, Shape: BHShape<T, D> + PointDistance<T, D>>(
+    fn nearest_to<'a, Shape: BHShape<T, D> + PointDistance<T, D>>(
         &'a self,
         query: Point<T, D>,
         shapes: &'a [Shape],
     ) -> Option<(&'a Shape, T)> {
-        H::nearest_from(self, query, shapes)
+        H::nearest_to(self, query, shapes)
     }
 
     fn build_with_executor<

--- a/src/bounding_hierarchy.rs
+++ b/src/bounding_hierarchy.rs
@@ -1,7 +1,8 @@
 //! This module defines the [`BoundingHierarchy`] trait.
 
 use nalgebra::{
-    ClosedAddAssign, ClosedDivAssign, ClosedMulAssign, ClosedSubAssign, Scalar, SimdPartialOrd,
+    ClosedAddAssign, ClosedDivAssign, ClosedMulAssign, ClosedSubAssign, Point, Scalar,
+    SimdPartialOrd,
 };
 use num::{Float, FromPrimitive, Signed};
 
@@ -245,6 +246,78 @@ pub trait BoundingHierarchy<T: BHValue, const D: usize> {
         shapes: &'a [Shape],
     ) -> Vec<&'a Shape>;
 
+    /// Traverses the [`BoundingHierarchy`].
+    /// Returns a subset of `shapes` which are candidates for being the closest to the query point.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bvh::aabb::{Aabb, Bounded};
+    /// use bvh::bounding_hierarchy::BoundingHierarchy;
+    /// use bvh::bvh::Bvh;
+    /// use nalgebra::{Point3, Vector3};
+    /// use bvh::ray::Ray;
+    /// # use bvh::bounding_hierarchy::BHShape;
+    /// # pub struct UnitBox {
+    /// #     pub id: i32,
+    /// #     pub pos: Point3<f32>,
+    /// #     node_index: usize,
+    /// # }
+    /// #
+    /// # impl UnitBox {
+    /// #     pub fn new(id: i32, pos: Point3<f32>) -> UnitBox {
+    /// #         UnitBox {
+    /// #             id: id,
+    /// #             pos: pos,
+    /// #             node_index: 0,
+    /// #         }
+    /// #     }
+    /// # }
+    /// #
+    /// # impl Bounded<f32,3> for UnitBox {
+    /// #     fn aabb(&self) -> Aabb<f32,3> {
+    /// #         let min = self.pos + Vector3::new(-0.5, -0.5, -0.5);
+    /// #         let max = self.pos + Vector3::new(0.5, 0.5, 0.5);
+    /// #         Aabb::with_bounds(min, max)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl BHShape<f32,3> for UnitBox {
+    /// #     fn set_bh_node_index(&mut self, index: usize) {
+    /// #         self.node_index = index;
+    /// #     }
+    /// #
+    /// #     fn bh_node_index(&self) -> usize {
+    /// #         self.node_index
+    /// #     }
+    /// # }
+    /// #
+    /// # fn create_bvh() -> (Bvh<f32,3>, Vec<UnitBox>) {
+    /// #     let mut shapes = Vec::new();
+    /// #     for i in 0..1000 {
+    /// #         let position = Point3::new(i as f32, i as f32, i as f32);
+    /// #         shapes.push(UnitBox::new(i, position));
+    /// #     }
+    /// #     let bvh = Bvh::build(&mut shapes);
+    /// #     (bvh, shapes)
+    /// # }
+    ///
+    /// let (bvh, shapes) = create_bvh();
+    ///
+    /// let query = Point3::new(5.0, 0.0, 2.0);
+    /// let direction = Vector3::new(1.0, 0.0, 0.0);
+    /// let hit_shapes = bvh.nearest_candidates(&query, &shapes);
+    /// ```
+    ///
+    /// [`BoundingHierarchy`]: trait.BoundingHierarchy.html
+    /// [`Aabb`]: ../aabb/struct.Aabb.html
+    ///
+    fn nearest_candidates<'a, Shape: BHShape<T, D>>(
+        &'a self,
+        query: &Point<T, D>,
+        shapes: &'a [Shape],
+    ) -> Vec<&Shape>;
+
     /// Prints the [`BoundingHierarchy`] in a tree-like visualization.
     ///
     /// [`BoundingHierarchy`]: trait.BoundingHierarchy.html
@@ -263,6 +336,14 @@ impl<T: BHValue, const D: usize, H: BoundingHierarchy<T, D>> BoundingHierarchy<T
         shapes: &'a [Shape],
     ) -> Vec<&'a Shape> {
         H::traverse(self, query, shapes)
+    }
+
+    fn nearest_candidates<'a, Shape: BHShape<T, D>>(
+        &'a self,
+        query: &Point<T, D>,
+        shapes: &'a [Shape],
+    ) -> Vec<&Shape> {
+        H::nearest_candidates(self, query, shapes)
     }
 
     fn build_with_executor<

--- a/src/bvh/bvh_impl.rs
+++ b/src/bvh/bvh_impl.rs
@@ -590,7 +590,7 @@ mod tests {
 
     #[test]
     /// Runs some primitive tests for distance query of a point with a fixed scene given as a [`Bvh`].
-    fn test_nearest_candidate_bvh() {
+    fn test_nearest_candidates_bvh() {
         nearest_candidates_some_bh::<TBvh3>();
     }
 
@@ -706,7 +706,9 @@ mod bench {
     use crate::testbase::{
         build_1200_triangles_bh, build_120k_triangles_bh, build_12k_triangles_bh,
         intersect_1200_triangles_bh, intersect_120k_triangles_bh, intersect_12k_triangles_bh,
-        intersect_bh, load_sponza_scene, TBvh3,
+        intersect_bh, load_sponza_scene, nearest_candidates_1200_triangles_bh,
+        nearest_candidates_120k_triangles_bh, nearest_candidates_12k_triangles_bh,
+        nearest_candidates_bh, TBvh3,
     };
     #[cfg(feature = "rayon")]
     use crate::testbase::{
@@ -794,5 +796,31 @@ mod bench {
         let (mut triangles, bounds) = load_sponza_scene();
         let bvh = TBvh3::build(&mut triangles);
         intersect_bh(&bvh, &triangles, &bounds, b)
+    }
+
+    #[bench]
+    /// Benchmark nearest candidates on 1,200 triangles using the recursive [`Bvh`].
+    fn bench_nearest_candidates_1200_triangles_bvh(b: &mut ::test::Bencher) {
+        nearest_candidates_1200_triangles_bh::<TBvh3>(b);
+    }
+
+    #[bench]
+    /// Benchmark nearest candidates on 12,000 triangles using the recursive [`Bvh`].
+    fn bench_nearest_candidates_12k_triangles_bvh(b: &mut ::test::Bencher) {
+        nearest_candidates_12k_triangles_bh::<TBvh3>(b);
+    }
+
+    #[bench]
+    /// Benchmark nearest candidates on 120,000 triangles using the recursive [`Bvh`].
+    fn bench_nearest_candidates_120k_triangles_bvh(b: &mut ::test::Bencher) {
+        nearest_candidates_120k_triangles_bh::<TBvh3>(b);
+    }
+
+    #[bench]
+    /// Benchmark nearest candidates on a [`Bvh`] with the Sponza scene.
+    fn bench_nearest_candidates_sponza_bvh(b: &mut ::test::Bencher) {
+        let (mut triangles, bounds) = load_sponza_scene();
+        let bvh = TBvh3::build(&mut triangles);
+        nearest_candidates_bh(&bvh, &triangles, &bounds, b)
     }
 }

--- a/src/bvh/bvh_node.rs
+++ b/src/bvh/bvh_node.rs
@@ -1,7 +1,6 @@
-use nalgebra::Point;
-
 use crate::aabb::{Aabb, Bounded, IntersectsAabb};
 use crate::bounding_hierarchy::{BHShape, BHValue};
+use crate::point_query::PointDistance;
 use crate::utils::{joint_aabb_of_shapes, Bucket};
 use std::cell::RefCell;
 use std::marker::PhantomData;
@@ -326,20 +325,18 @@ impl<T: BHValue, const D: usize> BvhNode<T, D> {
         }
     }
 
-    /// Traverses the [`Bvh`] recursively and returns all shapes whose [`Aabb`] countains
-    /// a candidate shape for being the nearest to the given point.
+    /// Traverses the [`Bvh`] recursively and updates the given `best_candidate` with
+    /// the nearest shape found so far.
     ///
     /// [`Aabb`]: ../aabb/struct.Aabb.html
     /// [`Bvh`]: struct.Bvh.html
     ///
-    pub fn nearest_candidates_recursive<Shape: Bounded<T, D>>(
+    pub fn nearest_from_recursive<'a, Shape: Bounded<T, D> + PointDistance<T, D>>(
         nodes: &[BvhNode<T, D>],
         node_index: usize,
-        origin: &Point<T, D>,
-        shapes: &[Shape],
-        indices: &mut Vec<(usize, T)>,
-        best_min_distance: &mut T,
-        best_max_distance: &mut T,
+        origin: nalgebra::Point<T, D>,
+        shapes: &'a [Shape],
+        best_candidate: &mut (&'a Shape, T),
     ) {
         match nodes[node_index] {
             BvhNode::Node {
@@ -349,53 +346,32 @@ impl<T: BHValue, const D: usize> BvhNode<T, D> {
                 child_r_index,
                 ..
             } => {
-                // Compute min/max dists for both children
-                let [child_l_dists, child_r_dists] =
-                    [child_l_aabb, child_r_aabb].map(|aabb| aabb.get_min_max_distances(origin));
+                // Compute the min dist for both children
+                let mut children = [
+                    (child_l_index, child_l_aabb.get_min_distance_2(origin)),
+                    (child_r_index, child_r_aabb.get_min_distance_2(origin)),
+                ];
 
-                // Update best max distance before traversing children to avoid unnecessary traversals
-                // where right node prunes left node.
-                *best_max_distance = best_max_distance.min(child_l_dists.1.min(child_r_dists.1));
+                // Sort children to go to the best candidate first and have a better chance of pruning
+                if children[0].1 > children[1].1 {
+                    children.swap(0, 1);
+                }
 
                 // Traverse children
-                for ((dist_min, dist_max), index) in [
-                    (child_l_dists, child_l_index),
-                    (child_r_dists, child_r_index),
-                ] {
-                    // Node is better by a margin.
-                    if dist_max <= *best_min_distance {
-                        indices.clear();
-                    }
-
-                    // Node might contain a candidate
-                    if dist_min <= *best_max_distance {
-                        Self::nearest_candidates_recursive(
-                            nodes,
-                            index,
-                            origin,
-                            shapes,
-                            indices,
-                            best_min_distance,
-                            best_max_distance,
-                        );
+                for (index, child_dist) in children {
+                    // Node might contain a better shape: check it.
+                    if child_dist <= best_candidate.1 {
+                        Self::nearest_from_recursive(nodes, index, origin, shapes, best_candidate);
                     }
                 }
             }
             BvhNode::Leaf { shape_index, .. } => {
-                let aabb = shapes[shape_index].aabb();
-                let (min_dist, max_dist) = aabb.get_min_max_distances(origin);
+                // This leaf might contain a better shape: check it directly with its exact distance (squared).
+                let dist = shapes[shape_index].distance_squared(origin);
 
-                if !indices.is_empty() && max_dist < *best_min_distance {
-                    // Node is better by a margin
-                    indices.clear();
+                if dist < best_candidate.1 {
+                    *best_candidate = (&shapes[shape_index], dist);
                 }
-
-                // Also update min_dist here since we have a credible (small) bounding box.
-                *best_min_distance = best_min_distance.min(min_dist);
-                *best_max_distance = best_max_distance.min(max_dist);
-
-                // we reached a leaf, we add it to the list of indices since it is a potential candidate
-                indices.push((shape_index, min_dist));
             }
         }
     }

--- a/src/flat_bvh.rs
+++ b/src/flat_bvh.rs
@@ -3,6 +3,7 @@ use crate::aabb::{Aabb, Bounded, IntersectsAabb};
 use crate::bounding_hierarchy::{BHShape, BHValue, BoundingHierarchy};
 use crate::bvh::{Bvh, BvhNode};
 
+use nalgebra::Point;
 use num::Float;
 
 /// A structure of a node of a flat [`Bvh`]. The structure of the nodes allows for an
@@ -417,6 +418,81 @@ impl<T: BHValue + std::fmt::Display, const D: usize> BoundingHierarchy<T, D> for
         }
 
         hit_shapes
+    }
+
+    /// Traverses a [`FlatBvh`] structure iteratively.
+    /// Returns a subset of `shapes` which are candidates for being the closest to the query point.
+    ///
+    ///
+    /// [`FlatBvh`]: struct.FlatBvh.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bvh::aabb::{Aabb, Bounded};
+    /// use bvh::bounding_hierarchy::BoundingHierarchy;
+    /// use bvh::flat_bvh::FlatBvh;
+    /// use nalgebra::{Point3, Vector3};
+    /// use bvh::ray::Ray;
+    /// # use bvh::bounding_hierarchy::BHShape;
+    /// # pub struct UnitBox {
+    /// #     pub id: i32,
+    /// #     pub pos: Point3<f32>,
+    /// #     node_index: usize,
+    /// # }
+    /// #
+    /// # impl UnitBox {
+    /// #     pub fn new(id: i32, pos: Point3<f32>) -> UnitBox {
+    /// #         UnitBox {
+    /// #             id: id,
+    /// #             pos: pos,
+    /// #             node_index: 0,
+    /// #         }
+    /// #     }
+    /// # }
+    /// #
+    /// # impl Bounded<f32,3> for UnitBox {
+    /// #     fn aabb(&self) -> Aabb<f32,3> {
+    /// #         let min = self.pos + Vector3::new(-0.5, -0.5, -0.5);
+    /// #         let max = self.pos + Vector3::new(0.5, 0.5, 0.5);
+    /// #         Aabb::with_bounds(min, max)
+    /// #     }
+    /// # }
+    /// #
+    /// # impl BHShape<f32,3> for UnitBox {
+    /// #     fn set_bh_node_index(&mut self, index: usize) {
+    /// #         self.node_index = index;
+    /// #     }
+    /// #
+    /// #     fn bh_node_index(&self) -> usize {
+    /// #         self.node_index
+    /// #     }
+    /// # }
+    /// #
+    /// # fn create_bhshapes() -> Vec<UnitBox> {
+    /// #     let mut shapes = Vec::new();
+    /// #     for i in 0..1000 {
+    /// #         let position = Point3::new(i as f32, i as f32, i as f32);
+    /// #         shapes.push(UnitBox::new(i, position));
+    /// #     }
+    /// #     shapes
+    /// # }
+    ///
+    /// let point = Point3::new(0.0,0.0,0.0);
+    /// let mut shapes = create_bhshapes();
+    /// let flat_bvh = FlatBvh::build(&mut shapes);
+    /// let candidates = flat_bvh.nearest_candidates(&point, &shapes);
+    /// ```
+    ///
+    /// [`BoundingHierarchy`]: trait.BoundingHierarchy.html
+    /// [`Aabb`]: ../aabb/struct.Aabb.html
+    ///
+    fn nearest_candidates<'a, Shape: BHShape<T, D>>(
+        &'a self,
+        _query: &Point<T, D>,
+        _shapes: &'a [Shape],
+    ) -> Vec<&Shape> {
+        todo!("Pre-order tree traversal with no recursion nor stack requires a parent index in the nodes.")
     }
 
     /// Prints a textual representation of a [`FlatBvh`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ pub mod ball;
 pub mod bounding_hierarchy;
 pub mod bvh;
 pub mod flat_bvh;
+pub mod point_query;
 pub mod ray;
 mod utils;
 

--- a/src/point_query.rs
+++ b/src/point_query.rs
@@ -1,9 +1,9 @@
-//! Contains the `PointDistance` trait used for querying the distance from a point to a bvh.
+//! Contains the `PointDistance` trait used for querying the distance to a point to a bvh.
 use crate::bounding_hierarchy::BHValue;
 
 /// A trait implemented by shapes that can be queried for their distance to a point.
 ///
-/// Used for the `Bvh::nearest_from` method that returns the closest shape from a point.
+/// Used for the `Bvh::nearest_to` method that returns the nearest shape to a point.
 pub trait PointDistance<T: BHValue, const D: usize> {
     /// Returns the squared distance from this point to the Shape.
     fn distance_squared(&self, query_point: nalgebra::Point<T, D>) -> T;

--- a/src/point_query.rs
+++ b/src/point_query.rs
@@ -1,0 +1,10 @@
+//! Contains the `PointDistance` trait used for querying the distance from a point to a bvh.
+use crate::bounding_hierarchy::BHValue;
+
+/// A trait implemented by shapes that can be queried for their distance to a point.
+///
+/// Used for the `Bvh::nearest_from` method that returns the closest shape from a point.
+pub trait PointDistance<T: BHValue, const D: usize> {
+    /// Returns the squared distance from this point to the Shape.
+    fn distance_squared(&self, query_point: nalgebra::Point<T, D>) -> T;
+}

--- a/src/testbase.rs
+++ b/src/testbase.rs
@@ -59,6 +59,7 @@ pub fn tuple_to_vector(tpl: &TupleVec) -> TVector3 {
 }
 
 /// Define some [`Bounded`] structure.
+#[derive(PartialEq)]
 pub struct UnitBox {
     pub id: i32,
     pub pos: TPoint3,
@@ -254,6 +255,48 @@ fn traverse_some_built_bh<BH: BoundingHierarchy<f32, 3>>(all_shapes: &[UnitBox],
         }
         traverse_and_verify(&sphere, all_shapes, &bh, &expected_shapes);
     }
+}
+
+/// Perform some fixed distance tests on [`BoundingHierarchy`] structures.
+pub fn nearest_candidates_some_bh<BH: BoundingHierarchy<f32, 3>>() {
+    let (all_shapes, bh) = build_some_bh::<BH>();
+
+    for point in [
+        TPoint3::new(0.0, 0.0, 0.0),
+        TPoint3::new(1.0, -0.5, 2.0),
+        TPoint3::new(2.0, 1.0, -1.3),
+        TPoint3::new(0.5, 0.0, -0.1),
+    ] {
+        nearest_candidates_and_verify(point, &all_shapes, &bh);
+    }
+}
+
+/// Given a query point, a bounding hierarchy, the complete list of shapes in the scene and a list of
+/// expected hits, verifies that nearest_candidates returns a list containing the correct answer.
+fn nearest_candidates_and_verify<BH: BoundingHierarchy<f32, 3>>(
+    query_point: TPoint3,
+    all_shapes: &[UnitBox],
+    bh: &BH,
+) {
+    let candidates = bh.nearest_candidates(&query_point, all_shapes);
+
+    let mut best = (&all_shapes[0], f32::MAX);
+    for shape in all_shapes {
+        let distance = (shape.pos - query_point).norm();
+        if distance < best.1 {
+            best = (shape, distance);
+        }
+    }
+
+    println!(
+        "Ratio {}",
+        candidates.len() as f32 / all_shapes.len() as f32
+    );
+    println!("Query point: {:?}", query_point);
+    println!("Best shape: {:?}", best.0.pos);
+    assert!(candidates.contains(&best.0));
+    // assert the function actually prunes.
+    assert!((candidates.len() as f32 / all_shapes.len() as f32) < 0.25);
 }
 
 /// A triangle struct. Instance of a more complex [`Bounded`] primitive.


### PR DESCRIPTION
I recently implemented a distance point query with a bvh for my crate mesh_to_sdf by trait extending this crate (see https://github.com/Azkellas/mesh_to_sdf/pull/75). This PR is an attempt to upstream the changes and would solve https://github.com/svenstaro/bvh/issues/56.

This PR is different from https://github.com/svenstaro/bvh/pull/43 which only returns shapes with aabb containing the query point. On the contrary, this PR returns a conservative list of candidates, one of which for sure contains the shape that is closest to the query point. This is needed since we can't know for sure if the query point is in the aabb of its closest object.

To do so, we keep track of the best minimum/maximum distance found yet in the tree. For each node we compute the aabb min/max distance from the point (the minimum is 0 if the point is inside). Then we can prune or investigate the subtrees depending on the aabb's min/max compared to the current best min/max.

This means the search visits a subtree and not a single linear branch. It might be interesting to add an `approx` version following https://github.com/svenstaro/bvh/pull/43 implementation which would be faster and "close enough".

I couldn't implement the `nearest_candidate` method for `FlatBvh`.  Pre-order no-stack no-recursion tree traversal requires to store the parent index in the node afaik. I didn't want to change the memory layout without talking about it first. This PR is in draft state for this reason.

Testing is a bit rudimentary (and no benchmark) as I did most of it in my crate and haven't ported it yet.
Anyway for 100k triangles and 15k queries (in mesh's bounding box) it is 10x faster than brute forcing while being exact.

Waht remains to be done:
- [x] Upstream tests and benches
- [x] Implement `nearest_candidate` for `FlatBvh`
- [x] Implement an `approx` version? At least test the performance gain.

Thank you for the work, this crate is very useful.