### PR TITLE
Fix typo in `farthest_traverse_iterator` docs

### DIFF
--- a/src/bvh/bvh_impl.rs
+++ b/src/bvh/bvh_impl.rs
@@ -145,7 +145,7 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
 
     /// Creates a [`DistanceTraverseIterator`] to traverse the [`Bvh`].
     /// Returns a subset of [`Shape`], in which the [`Aabb`]s of the elements were hit by [`Ray`].
-    /// Return in order from nearest to farthest for ray.
+    /// Return in order from farthest to nearest for ray.
     ///
     /// [`Bvh`]: struct.Bvh.html
     /// [`Aabb`]: ../aabb/struct.AABB.html


### PR DESCRIPTION
The docs for `nearest_traverse_iterator` and the docs for `farthest_traverse_iterator` are the same, and should not be.
Where `farthest_traverse_iterator` should say **farthest to nearest**, it (wrongly) says **nearest to farthest**.

```rust
    /// Creates a [`DistanceTraverseIterator`] to traverse the [`Bvh`].
    /// Returns a subset of [`shape`], in which the [`Aabb`]s of the elements were hit by [`Ray`].
    /// Return in order from nearest to farthest for ray.
    ///
    /// [`Bvh`]: struct.Bvh.html
    /// [`Aabb`]: ../aabb/struct.AABB.html
    ///
    pub fn nearest_traverse_iterator...
```

```rust
    /// Creates a [`DistanceTraverseIterator`] to traverse the [`Bvh`].
    /// Returns a subset of [`Shape`], in which the [`Aabb`]s of the elements were hit by [`Ray`].
    /// Return in order from nearest to farthest for ray.
    ///
    /// [`Bvh`]: struct.Bvh.html
    /// [`Aabb`]: ../aabb/struct.AABB.html
    ///
    pub fn farthest_traverse_iterator...
```

Proposed fix:

```rust
    ...
    /// Return in order from farthest to nearest for ray.
    ...    
    pub fn farthest_traverse_iterator...
```