### PR TITLE
Fix panic on empty `DistanceTraverseIterator`

### DIFF
--- a/src/bvh/distance_traverse.rs
+++ b/src/bvh/distance_traverse.rs
@@ -50,7 +50,7 @@ where
             stack: [(0, RestChild::None); 32],
             node_index: 0,
             stack_size: 0,
-            has_node: true,
+            has_node: !bvh.nodes.is_empty(),
         }
     }
 


### PR DESCRIPTION
Fixed a bug causing a panic when attempting to iterate through an empty `DistanceTraverseIterator`.

Basic reproducible example of the issue (adapted from the `example.rs` code):

```rust
use bvh::aabb::{Aabb, Bounded};
use bvh::bounding_hierarchy::BHShape;
use bvh::bvh::Bvh;
use bvh::ray::Ray;
use nalgebra::{Point, SVector};

pub fn main() {
    // Construct an empty BVH
    let mut spheres: Vec<Sphere> = Vec::new();
    let bvh = Bvh::build(&mut spheres);

    let origin = Point::<f32, 3>::new(0.0, 0.0, 0.0);
    let direction = SVector::<f32, 3>::new(1.0, 0.0, 0.0);
    let ray = Ray::new(origin, direction);

    // Trying to iterate through nearest_traverse_iterator results in a panic
    for _ in bvh.nearest_traverse_iterator(&ray, &spheres) {
        println!("hi mom");
    }

    // Trying to iterate through farthest_traverse_iterator also results in a panic
    for _ in bvh.farthest_traverse_iterator(&ray, &spheres) {
        println!("hi dad");
    }

    println!("we made it!");
}

// SETUP STUFF, NOT IMPORTANT
#[derive(Debug)]
struct Sphere {
    position: Point<f32, 3>,
    radius: f32,
    node_index: usize,
}

impl Bounded<f32, 3> for Sphere {
    fn aabb(&self) -> Aabb<f32, 3> {
        let half_size = SVector::<f32, 3>::new(self.radius, self.radius, self.radius);
        let min = self.position - half_size;
        let max = self.position + half_size;
        Aabb::with_bounds(min, max)
    }
}

impl BHShape<f32, 3> for Sphere {
    fn set_bh_node_index(&mut self, index: usize) {
        self.node_index = index;
    }

    fn bh_node_index(&self) -> usize {
        self.node_index
    }
}
```

Output without my fix:
```
thread 'main' panicked at src/bvh/distance_traverse.rs:140:29:
index out of bounds: the len is 0 but the index is 0
```

Output after applying the fix:
```
we made it!
```