### PR TITLE
Don't panic on empty BVH (additional cases)

### DIFF
--- a/src/bvh/bvh_impl.rs
+++ b/src/bvh/bvh_impl.rs
@@ -257,7 +257,7 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
     pub fn is_consistent<Shape: BHShape<T, D>>(&self, shapes: &[Shape]) -> bool {
         if self.nodes.is_empty() {
             // There is no node_index=0.
-            return vec;
+            return true;
         }
 
         // The root node of the bvh is not bounded by anything.
@@ -349,7 +349,7 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
     {
         if self.nodes.is_empty() {
             // There is no node_index=0.
-            return vec;
+            return;
         }
 
         // The root node of the bvh is not bounded by anything.
@@ -388,7 +388,7 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
     pub fn assert_tight(&self) {
         if self.nodes.is_empty() {
             // There is no node_index=0.
-            return vec;
+            return;
         }
         // When starting to check whether the `Bvh` is tight, we cannot provide a minimum
         // outer `Aabb`, therefore we compute the correct one in this instance.
@@ -454,12 +454,25 @@ pub fn rayon_executor<S, T: Send + BHValue, const D: usize>(
 
 #[cfg(test)]
 mod tests {
-    use crate::testbase::{build_some_bh, traverse_some_bh, TBvh3, TBvhNode3};
+    use crate::testbase::{build_empty_bh, build_some_bh, traverse_some_bh, TBvh3, TBvhNode3};
 
     #[test]
     /// Tests whether the building procedure succeeds in not failing.
     fn test_build_bvh() {
         build_some_bh::<TBvh3>();
+    }
+
+    #[test]
+    fn test_empty_bvh_is_consistent() {
+        let (shapes, bvh) = build_empty_bh::<TBvh3>();
+        bvh.assert_consistent(&shapes);
+        assert!(bvh.is_consistent(&shapes));
+    }
+
+    #[test]
+    fn test_empty_bvh_is_tight() {
+        let (_, bvh) = build_empty_bh::<TBvh3>();
+        bvh.assert_tight();
     }
 
     #[test]

--- a/src/bvh/bvh_impl.rs
+++ b/src/bvh/bvh_impl.rs
@@ -255,6 +255,11 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
     /// Checks if all children of a node have the correct parent index, and that there is no
     /// detached subtree. Also checks if the `Aabb` hierarchy is consistent.
     pub fn is_consistent<Shape: BHShape<T, D>>(&self, shapes: &[Shape]) -> bool {
+        if self.nodes.is_empty() {
+            // There is no node_index=0.
+            return vec;
+        }
+
         // The root node of the bvh is not bounded by anything.
         let space = Aabb::infinite();
 
@@ -342,6 +347,11 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
     where
         T: std::fmt::Display,
     {
+        if self.nodes.is_empty() {
+            // There is no node_index=0.
+            return vec;
+        }
+
         // The root node of the bvh is not bounded by anything.
         let space = Aabb::infinite();
 
@@ -376,6 +386,10 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
     /// Check that the `Aabb`s in the `Bvh` are tight, which means, that parent `Aabb`s are not
     /// larger than they should be.
     pub fn assert_tight(&self) {
+        if self.nodes.is_empty() {
+            // There is no node_index=0.
+            return vec;
+        }
         // When starting to check whether the `Bvh` is tight, we cannot provide a minimum
         // outer `Aabb`, therefore we compute the correct one in this instance.
         if let BvhNode::Node {

--- a/src/flat_bvh.rs
+++ b/src/flat_bvh.rs
@@ -382,7 +382,7 @@ impl<T: BHValue + std::fmt::Display, const D: usize> BoundingHierarchy<T, D> for
     /// let flat_bvh = FlatBvh::build(&mut shapes);
     /// let hit_shapes = flat_bvh.traverse(&ray, &shapes);
     /// ```
-    fn traverse<'a, B: Bounded<T, D>>(&'a self, ray: &Ray<T, D>, shapes: &'a [B]) -> Vec<&B> {
+    fn traverse<'a, B: Bounded<T, D>>(&'a self, ray: &Ray<T, D>, shapes: &'a [B]) -> Vec<&'a B> {
         let mut hit_shapes = Vec::new();
         let mut index = 0;
 

--- a/src/flat_bvh.rs
+++ b/src/flat_bvh.rs
@@ -446,7 +446,7 @@ impl<T: BHValue + std::fmt::Display, const D: usize> BoundingHierarchy<T, D> for
 
 #[cfg(test)]
 mod tests {
-    use crate::testbase::{build_some_bh, traverse_some_bh, TFlatBvh3};
+    use crate::testbase::{build_empty_bh, build_some_bh, traverse_some_bh, TBvh3, TFlatBvh3};
 
     #[test]
     /// Tests whether the building procedure succeeds in not failing.
@@ -459,6 +459,13 @@ mod tests {
     /// as a `FlatBvh`.
     fn test_traverse_flat_bvh() {
         traverse_some_bh::<TFlatBvh3>();
+    }
+
+    #[test]
+    fn test_flatten_empty_bvh() {
+        let (_, bvh) = build_empty_bh::<TBvh3>();
+        let flat = bvh.flatten();
+        assert!(flat.is_empty());
     }
 }
 

--- a/src/flat_bvh.rs
+++ b/src/flat_bvh.rs
@@ -231,6 +231,10 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
         F: Fn(&Aabb<T, D>, u32, u32, u32) -> FNodeType,
     {
         let mut vec = Vec::new();
+        if self.nodes.is_empty() {
+            // There is no node_index=0.
+            return vec;
+        }
         self.nodes[0].flatten_custom(&self.nodes, &mut vec, 0, constructor);
         vec
     }
@@ -378,7 +382,7 @@ impl<T: BHValue + std::fmt::Display, const D: usize> BoundingHierarchy<T, D> for
     /// let flat_bvh = FlatBvh::build(&mut shapes);
     /// let hit_shapes = flat_bvh.traverse(&ray, &shapes);
     /// ```
-    fn traverse<'a, B: Bounded<T, D>>(&'a self, ray: &Ray<T, D>, shapes: &'a [B]) -> Vec<&'a B> {
+    fn traverse<'a, B: Bounded<T, D>>(&'a self, ray: &Ray<T, D>, shapes: &'a [B]) -> Vec<&B> {
         let mut hit_shapes = Vec::new();
         let mut index = 0;
 

--- a/src/testbase.rs
+++ b/src/testbase.rs
@@ -119,6 +119,13 @@ pub fn build_some_bh_rayon<BH: BoundingHierarchy<f32, 3>>() -> (Vec<UnitBox>, BH
     (boxes, bh)
 }
 
+/// Creates a [`BoundingHierarchy`] for an empty scene structure.
+pub fn build_empty_bh<BH: BoundingHierarchy<f32, 3>>() -> (Vec<UnitBox>, BH) {
+    let mut boxes = Vec::new();
+    let bh = BH::build(&mut boxes);
+    (boxes, bh)
+}
+
 /// Given a ray, a bounding hierarchy, the complete list of shapes in the scene and a list of
 /// expected hits, verifies, whether the ray hits only the expected shapes.
 fn traverse_and_verify<BH: BoundingHierarchy<f32, 3>>(


### PR DESCRIPTION
- [x] Don't panic on empty BVH
  - [x] `assert_consistent` returns successfuly on an empty BVH
  - [x] `assert_tight` returns successfully on an empty BVH
  - [x] `is_consistent` returns `true` on an empty BVH
  - [x] `flatten` returns an empty flat BVH on an empty BVH
  - [ ] ~~Nearest/farthest iterators work on empty BVH~~ (merge #117 instead)

All fixes are unit-tested.

Followup to #113 