### PR TITLE
Aabb center() works even if size() overflows to infinity.

### DIFF
--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -477,7 +477,8 @@ impl<T: BHValue, const D: usize> Aabb<T, D> {
     /// [`Point3`]: nalgebra::Point3
     ///
     pub fn center(&self) -> Point<T, D> {
-        (self.min.coords + (self.size() * T::from_f32(0.5).unwrap())).into()
+        (self.min.coords * T::from_f32(0.5).unwrap() + self.max.coords * T::from_f32(0.5).unwrap())
+            .into()
     }
 
     /// An empty [`Aabb`] is an [`Aabb`] where the lower bound is greater than
@@ -668,6 +669,25 @@ mod tests {
 
     use float_eq::assert_float_eq;
     use proptest::prelude::*;
+
+    #[test]
+    fn test_overflowing_aabb_center() {
+        // Define two points which will be the corners of the overflowing `Aabb`
+        let p1 = tuple_to_point(&(-3.288583e38, 0.0, 0.0));
+        let p2 = tuple_to_point(&(5.4196525e37, 0.0, 0.0));
+
+        // Span the `Aabb`
+        let aabb = TAabb3::empty().grow(&p1).join_bounded(&p2);
+
+        // Make sure the size actually overflows.
+        assert!(aabb.size()[0].is_infinite());
+
+        // Make sure the center does not overflow.
+        assert!(aabb.center()[0].is_finite());
+
+        // Its center should inside the `Aabb`
+        assert!(aabb.contains(&aabb.center()));
+    }
 
     proptest! {
         // Test whether an empty `Aabb` does not contains anything.


### PR DESCRIPTION
## Motivation
On the latest GitHub actions run for #113, an existing proptest failed for an unrelated reason: In the unlikely event that the two random points are *very* far apart, the AABB has non-finite size, and so the center (which is min+size/2) has non-finite dimensions.

```
thread 'aabb::tests::test_aabb_contains_center' panicked at src/aabb.rs:710:13:
assertion failed: aabb.contains(&aabb.center())
proptest: Saving this and future failures in /home/runner/work/bvh/bvh/proptest-regressions/aabb.txt
proptest: If this test was run on a CI system, you may wish to add the following line to your copy of the file. (You may need to create it.)
cc 0e70e0f10c7987ea4ea9eef3d97c4838a744dc25bc9c837fe27f3262dea5d8a4

thread 'aabb::tests::test_aabb_contains_center' panicked at src/aabb.rs:672:5:
Test failed: assertion failed: aabb.contains(&aabb.center()).
minimal failing input: a = (
    -3.288583e38,
    0.0,
    0.0,
), b = (
    5.4196525e37,
    0.0,
    -0.0,
)
```

## Description
This PR changes the implementation of center to avoid the overflow.

## Performance
There is one fewer vector-vector subtraction but one more vector-scalar multiplication. This could affect performance. I benchmarked using `cargo bench --features bench` on an i7-7700k:

<details>
<summary>Before</summary>

```
test bvh::bvh_impl::bench::bench_build_1200_triangles_bvh                     ... bench:     240,658.65 ns/iter (+/- 10,583.26)
test bvh::bvh_impl::bench::bench_build_1200_triangles_bvh_rayon               ... bench:     117,099.52 ns/iter (+/- 15,944.52)
test bvh::bvh_impl::bench::bench_build_120k_triangles_bvh                     ... bench:  38,440,816.30 ns/iter (+/- 3,284,163.05)
test bvh::bvh_impl::bench::bench_build_120k_triangles_bvh_rayon               ... bench:  11,408,088.20 ns/iter (+/- 1,639,008.22)
test bvh::bvh_impl::bench::bench_build_12k_triangles_bvh                      ... bench:   3,059,350.20 ns/iter (+/- 305,714.49)
test bvh::bvh_impl::bench::bench_build_12k_triangles_bvh_rayon                ... bench:     970,051.75 ns/iter (+/- 298,373.28)
test bvh::bvh_impl::bench::bench_build_sponza_bvh                             ... bench:  23,667,159.40 ns/iter (+/- 1,494,813.96)
test bvh::bvh_impl::bench::bench_build_sponza_bvh_rayon                       ... bench:   6,341,784.10 ns/iter (+/- 919,873.50)
test bvh::bvh_impl::bench::bench_intersect_1200_triangles_bvh                 ... bench:         141.07 ns/iter (+/- 1.45)
test bvh::bvh_impl::bench::bench_intersect_120k_triangles_bvh                 ... bench:         873.41 ns/iter (+/- 9.31)
test bvh::bvh_impl::bench::bench_intersect_12k_triangles_bvh                  ... bench:         367.14 ns/iter (+/- 3.78)
test bvh::bvh_impl::bench::bench_intersect_sponza_bvh                         ... bench:       1,369.08 ns/iter (+/- 93.50)
test bvh::iter::bench::bench_intersect_128rays_sponza_iter                    ... bench:     185,966.38 ns/iter (+/- 13,810.31)
test bvh::iter::bench::bench_intersect_128rays_sponza_vec                     ... bench:     174,464.30 ns/iter (+/- 8,451.20)
test bvh::optimization::bench::bench_intersect_120k_after_update_shapes_00p   ... bench:         880.76 ns/iter (+/- 48.10)
test bvh::optimization::bench::bench_intersect_120k_after_update_shapes_01p   ... bench:         974.78 ns/iter (+/- 105.48)
test bvh::optimization::bench::bench_intersect_120k_after_update_shapes_10p   ... bench:       3,070.93 ns/iter (+/- 695.45)
test bvh::optimization::bench::bench_intersect_120k_after_update_shapes_50p   ... bench:       3,646.47 ns/iter (+/- 719.11)
test bvh::optimization::bench::bench_intersect_120k_with_rebuild_00p          ... bench:         887.29 ns/iter (+/- 39.47)
test bvh::optimization::bench::bench_intersect_120k_with_rebuild_01p          ... bench:         971.26 ns/iter (+/- 80.08)
test bvh::optimization::bench::bench_intersect_120k_with_rebuild_10p          ... bench:       1,946.50 ns/iter (+/- 221.71)
test bvh::optimization::bench::bench_intersect_120k_with_rebuild_50p          ... bench:       2,511.74 ns/iter (+/- 518.40)
test bvh::optimization::bench::bench_intersect_sponza_after_update_shapes_00p ... bench:       1,389.32 ns/iter (+/- 147.48)
test bvh::optimization::bench::bench_intersect_sponza_after_update_shapes_01p ... bench:       4,035.73 ns/iter (+/- 330.99)
test bvh::optimization::bench::bench_intersect_sponza_after_update_shapes_10p ... bench:      22,504.44 ns/iter (+/- 1,971.46)
test bvh::optimization::bench::bench_intersect_sponza_after_update_shapes_50p ... bench:      14,395.30 ns/iter (+/- 2,294.38)
test bvh::optimization::bench::bench_intersect_sponza_with_rebuild_00p        ... bench:       1,340.49 ns/iter (+/- 22.63)
test bvh::optimization::bench::bench_intersect_sponza_with_rebuild_01p        ... bench:       1,482.61 ns/iter (+/- 39.61)
test bvh::optimization::bench::bench_intersect_sponza_with_rebuild_10p        ... bench:       1,917.82 ns/iter (+/- 117.08)
test bvh::optimization::bench::bench_intersect_sponza_with_rebuild_50p        ... bench:       2,554.13 ns/iter (+/- 74.67)
test bvh::optimization::bench::bench_randomize_120k_50p                       ... bench:   5,739,389.50 ns/iter (+/- 403,074.55)
test bvh::optimization::bench::bench_update_shapes_bvh_120k_00p               ... bench:     894,138.80 ns/iter (+/- 6,759.13)
test bvh::optimization::bench::bench_update_shapes_bvh_120k_01p               ... bench:   2,400,914.20 ns/iter (+/- 786,282.90)
test bvh::optimization::bench::bench_update_shapes_bvh_120k_10p               ... bench:  17,930,878.70 ns/iter (+/- 567,940.72)
test bvh::optimization::bench::bench_update_shapes_bvh_120k_50p               ... bench:  80,103,534.00 ns/iter (+/- 2,046,329.17)
test flat_bvh::bench::bench_build_1200_triangles_flat_bvh                     ... bench:     265,438.73 ns/iter (+/- 6,795.24)
test flat_bvh::bench::bench_build_120k_triangles_flat_bvh                     ... bench:  51,608,052.90 ns/iter (+/- 566,799.13)
test flat_bvh::bench::bench_build_12k_triangles_flat_bvh                      ... bench:   3,195,619.20 ns/iter (+/- 164,173.97)
test flat_bvh::bench::bench_flatten_120k_triangles_bvh                        ... bench:   2,997,062.40 ns/iter (+/- 374,007.78)
test flat_bvh::bench::bench_intersect_1200_triangles_flat_bvh                 ... bench:         149.69 ns/iter (+/- 4.70)
test flat_bvh::bench::bench_intersect_120k_triangles_flat_bvh                 ... bench:         994.78 ns/iter (+/- 53.90)
test flat_bvh::bench::bench_intersect_12k_triangles_flat_bvh                  ... bench:         397.43 ns/iter (+/- 8.12)
test ray::ray_impl::bench::bench_intersects_aabb                              ... bench:       5,326.23 ns/iter (+/- 424.24)
test testbase::bench_intersect_120k_triangles_list                            ... bench:     743,917.94 ns/iter (+/- 192,760.78)
test testbase::bench_intersect_120k_triangles_list_aabb                       ... bench:     761,291.14 ns/iter (+/- 77,126.47)
test testbase::bench_intersect_sponza_list                                    ... bench:     505,179.24 ns/iter (+/- 22,334.04)
test testbase::bench_intersect_sponza_list_aabb                               ... bench:     352,633.47 ns/iter (+/- 32,150.39)
```
</details>

<details>
<summary>After</summary>

```
test bvh::bvh_impl::bench::bench_build_1200_triangles_bvh                     ... bench:     248,216.89 ns/iter (+/- 14,514.10)
test bvh::bvh_impl::bench::bench_build_1200_triangles_bvh_rayon               ... bench:     113,180.34 ns/iter (+/- 13,322.94)
test bvh::bvh_impl::bench::bench_build_120k_triangles_bvh                     ... bench:  38,261,323.50 ns/iter (+/- 4,058,144.04)
test bvh::bvh_impl::bench::bench_build_120k_triangles_bvh_rayon               ... bench:  12,235,077.90 ns/iter (+/- 3,021,018.48)
test bvh::bvh_impl::bench::bench_build_12k_triangles_bvh                      ... bench:   3,048,291.10 ns/iter (+/- 291,647.54)
test bvh::bvh_impl::bench::bench_build_12k_triangles_bvh_rayon                ... bench:   1,002,808.25 ns/iter (+/- 405,075.70)
test bvh::bvh_impl::bench::bench_build_sponza_bvh                             ... bench:  22,841,404.70 ns/iter (+/- 1,215,941.42)
test bvh::bvh_impl::bench::bench_build_sponza_bvh_rayon                       ... bench:   6,317,762.10 ns/iter (+/- 729,871.07)
test bvh::bvh_impl::bench::bench_intersect_1200_triangles_bvh                 ... bench:         141.62 ns/iter (+/- 5.84)
test bvh::bvh_impl::bench::bench_intersect_120k_triangles_bvh                 ... bench:         858.05 ns/iter (+/- 11.41)
test bvh::bvh_impl::bench::bench_intersect_12k_triangles_bvh                  ... bench:         367.78 ns/iter (+/- 14.14)
test bvh::bvh_impl::bench::bench_intersect_sponza_bvh                         ... bench:       1,375.89 ns/iter (+/- 312.44)
test bvh::iter::bench::bench_intersect_128rays_sponza_iter                    ... bench:     178,300.77 ns/iter (+/- 17,816.89)
test bvh::iter::bench::bench_intersect_128rays_sponza_vec                     ... bench:     174,533.18 ns/iter (+/- 46,322.66)
test bvh::optimization::bench::bench_intersect_120k_after_update_shapes_00p   ... bench:         863.98 ns/iter (+/- 32.25)
test bvh::optimization::bench::bench_intersect_120k_after_update_shapes_01p   ... bench:         943.52 ns/iter (+/- 81.59)
test bvh::optimization::bench::bench_intersect_120k_after_update_shapes_10p   ... bench:       3,278.10 ns/iter (+/- 795.64)
test bvh::optimization::bench::bench_intersect_120k_after_update_shapes_50p   ... bench:       3,600.28 ns/iter (+/- 1,154.13)
test bvh::optimization::bench::bench_intersect_120k_with_rebuild_00p          ... bench:         869.38 ns/iter (+/- 97.42)
test bvh::optimization::bench::bench_intersect_120k_with_rebuild_01p          ... bench:         938.44 ns/iter (+/- 75.74)
test bvh::optimization::bench::bench_intersect_120k_with_rebuild_10p          ... bench:       2,032.47 ns/iter (+/- 859.53)
test bvh::optimization::bench::bench_intersect_120k_with_rebuild_50p          ... bench:       2,208.40 ns/iter (+/- 133.22)
test bvh::optimization::bench::bench_intersect_sponza_after_update_shapes_00p ... bench:       1,370.45 ns/iter (+/- 190.71)
test bvh::optimization::bench::bench_intersect_sponza_after_update_shapes_01p ... bench:       4,821.47 ns/iter (+/- 1,231.35)
test bvh::optimization::bench::bench_intersect_sponza_after_update_shapes_10p ... bench:      25,264.57 ns/iter (+/- 4,751.09)
test bvh::optimization::bench::bench_intersect_sponza_after_update_shapes_50p ... bench:      16,859.13 ns/iter (+/- 1,850.83)
test bvh::optimization::bench::bench_intersect_sponza_with_rebuild_00p        ... bench:       1,330.29 ns/iter (+/- 80.98)
test bvh::optimization::bench::bench_intersect_sponza_with_rebuild_01p        ... bench:       1,472.98 ns/iter (+/- 113.74)
test bvh::optimization::bench::bench_intersect_sponza_with_rebuild_10p        ... bench:       1,889.60 ns/iter (+/- 63.19)
test bvh::optimization::bench::bench_intersect_sponza_with_rebuild_50p        ... bench:       2,516.56 ns/iter (+/- 135.15)
test bvh::optimization::bench::bench_randomize_120k_50p                       ... bench:   5,723,161.00 ns/iter (+/- 357,808.20)
test bvh::optimization::bench::bench_update_shapes_bvh_120k_00p               ... bench:     906,789.30 ns/iter (+/- 6,412.24)
test bvh::optimization::bench::bench_update_shapes_bvh_120k_01p               ... bench:   2,399,585.62 ns/iter (+/- 96,633.79)
test bvh::optimization::bench::bench_update_shapes_bvh_120k_10p               ... bench:  17,935,963.30 ns/iter (+/- 3,421,224.43)
test bvh::optimization::bench::bench_update_shapes_bvh_120k_50p               ... bench:  86,633,616.60 ns/iter (+/- 22,392,709.24)
test flat_bvh::bench::bench_build_1200_triangles_flat_bvh                     ... bench:     282,605.32 ns/iter (+/- 16,286.75)
test flat_bvh::bench::bench_build_120k_triangles_flat_bvh                     ... bench:  42,353,233.30 ns/iter (+/- 4,838,812.94)
test flat_bvh::bench::bench_build_12k_triangles_flat_bvh                      ... bench:   3,309,687.42 ns/iter (+/- 458,791.56)
test flat_bvh::bench::bench_flatten_120k_triangles_bvh                        ... bench:   3,470,779.65 ns/iter (+/- 262,306.45)
test flat_bvh::bench::bench_intersect_1200_triangles_flat_bvh                 ... bench:         149.69 ns/iter (+/- 2.82)
test flat_bvh::bench::bench_intersect_120k_triangles_flat_bvh                 ... bench:         979.08 ns/iter (+/- 26.82)
test flat_bvh::bench::bench_intersect_12k_triangles_flat_bvh                  ... bench:         399.24 ns/iter (+/- 10.32)
test ray::ray_impl::bench::bench_intersects_aabb                              ... bench:       5,043.21 ns/iter (+/- 109.77)
test testbase::bench_intersect_120k_triangles_list                            ... bench:     654,403.44 ns/iter (+/- 40,398.12)
test testbase::bench_intersect_120k_triangles_list_aabb                       ... bench:     735,552.66 ns/iter (+/- 51,827.44)
test testbase::bench_intersect_sponza_list                                    ... bench:     479,068.36 ns/iter (+/- 21,191.56)
test testbase::bench_intersect_sponza_list_aabb                               ... bench:     352,085.88 ns/iter (+/- 39,846.52)
```
</details>

I didn't notice any significant regressions.