### PR TITLE
Add generic traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add fuzzing suite [#113](https://github.com/svenstaro/bvh/pull/113) (thanks @finnbear)
 - Fix some assertions [#129](https://github.com/svenstaro/bvh/pull/129) (thanks @finnbear)
 - Fix traversal in case of single-node BVH [#130](https://github.com/svenstaro/bvh/pull/130) (thanks @finnbear)
+- **Breaking change:** BVH traversal now accepts a `Query: IntersectsAabb` rather than a `Ray`,
+  allowing points, AABB's, and circles/spheres to be tested, too. Most use-cases involving `Ray` 
+  will continue to compile as-is. If you previously wrote `BvhTraverseIterator<T, D, S>`, you'll
+  need to change it to `BvhTraverseIterator<T, D, Ray, S>`. [#128](https://github.com/svenstaro/bvh/pull/128) (thanks @finnbear)
 
 ## 0.10.0 - 2024-07-06
 - Don't panic when traversing empty BVH [#106](https://github.com/svenstaro/bvh/pull/106) (thanks @finnbear)

--- a/src/aabb/aabb_impl.rs
+++ b/src/aabb/aabb_impl.rs
@@ -223,6 +223,30 @@ impl<T: BHValue, const D: usize> Aabb<T, D> {
             && self.approx_contains_eps(&other.max, epsilon)
     }
 
+    /// Returns true if this [`Aabb`] touches the `other` [`Aabb`].
+    ///
+    /// # Examples
+    /// ```
+    /// use bvh::aabb::Aabb;
+    /// use nalgebra::Point3;
+    ///
+    /// let aabb1 = Aabb::with_bounds(Point3::new(-1.0, -1.0, -1.0), Point3::new(1.0, 1.0, 1.0));
+    /// let aabb2 = Aabb::with_bounds(Point3::new(0.5, -0.1, -0.1), Point3::new(1.5, 0.1, 0.1));
+    ///
+    /// assert!(aabb1.intersects_aabb(&aabb2));
+    /// ```
+    ///
+    /// [`Aabb`]: struct.Aabb.html
+    pub fn intersects_aabb(&self, aabb: &Aabb<T, D>) -> bool {
+        // TODO: Try adding a SIMD specialization.
+        for i in 0..D {
+            if self.max[i] < aabb.min[i] || aabb.max[i] < self.min[i] {
+                return false;
+            }
+        }
+        true
+    }
+
     /// Returns true if the `other` [`Aabb`] is approximately equal to this [`Aabb`]
     /// with respect to some `epsilon`.
     ///
@@ -688,6 +712,32 @@ mod tests {
     }
 
     proptest! {
+        // Test properties of `Aabb` intersection.
+        #[test]
+        fn test_intersecting_aabbs(a: TupleVec, b: TupleVec, c: TupleVec, d: TupleVec, p: TupleVec) {
+            let a = tuple_to_point(&a);
+            let b = tuple_to_point(&b);
+            let c = tuple_to_point(&c);
+            let d = tuple_to_point(&d);
+            let aabb1 = TAabb3::empty().grow(&a).join_bounded(&b);
+            let aabb2 = TAabb3::empty().grow(&c).join_bounded(&d);
+            if aabb1.intersects_aabb(&aabb2) {
+                // For intersecting Aabb's, at least one point is shared.
+                let mut closest = aabb1.center();
+                for i in 0..3 {
+                    closest[i] = closest[i].clamp(aabb2.min[i], aabb2.max[i]);
+                }
+                assert!(aabb1.contains(&closest), "closest={closest:?}");
+                assert!(aabb2.contains(&closest), "closest={closest:?}");
+            } else {
+                // For non-intersecting Aabb's, no point can't be in both Aabb's.
+                let p = tuple_to_point(&p);
+                for point in [a, b, c, d, p] {
+                    assert!(!aabb1.contains(&point) || !aabb2.contains(&point));
+                }
+            }
+        }
+
         // Test whether an empty `Aabb` does not contains anything.
         #[test]
         fn test_empty_contains_nothing(tpl: TupleVec) {

--- a/src/aabb/aabb_impl.rs
+++ b/src/aabb/aabb_impl.rs
@@ -1,5 +1,3 @@
-//! Axis Aligned Bounding Boxes.
-
 use nalgebra::{Point, SVector};
 use std::fmt;
 use std::ops::Index;

--- a/src/aabb/intersection.rs
+++ b/src/aabb/intersection.rs
@@ -5,7 +5,9 @@ use crate::{aabb::Aabb, bounding_hierarchy::BHValue};
 /// A trait implemented by things that may or may not intersect an AABB and, by extension,
 /// things that can be used to traverse a BVH.
 pub trait IntersectsAabb<T: BHValue, const D: usize> {
-    /// Returns whether this object intersects an [`Aabb`].
+    /// Returns whether this object intersects an [`Aabb`]. For the purpose of intersection,
+    /// the [`Aabb`] is a solid with area/volume. As a result, intersecting an [`Aabb`]
+    /// implies intersecting any [`Aabb`] that contains that [`Aabb`].
     ///
     /// # Examples
     /// ```

--- a/src/aabb/intersection.rs
+++ b/src/aabb/intersection.rs
@@ -1,0 +1,48 @@
+use nalgebra::Point;
+
+use crate::{aabb::Aabb, bounding_hierarchy::BHValue};
+
+/// A trait implemented by things that may or may not intersect an AABB and, by extension,
+/// things that can be used to traverse a BVH.
+pub trait IntersectsAabb<T: BHValue, const D: usize> {
+    /// Returns whether this object intersects an [`Aabb`].
+    ///
+    /// # Examples
+    /// ```
+    /// use bvh::aabb::{Aabb, IntersectsAabb};
+    /// use nalgebra::Point3;
+    ///
+    /// struct XyPlane;
+    ///
+    /// impl IntersectsAabb<f32,3> for XyPlane {
+    ///     fn intersects_aabb(&self, aabb: &Aabb<f32,3>) -> bool {
+    ///         aabb.min[2] <= 0.0 && aabb.max[2] >= 0.0
+    ///     }
+    /// }
+    ///
+    /// let xy_plane = XyPlane;
+    /// let aabb = Aabb::with_bounds(Point3::new(-1.0,-1.0,-1.0), Point3::new(1.0,1.0,1.0));
+    /// assert!(xy_plane.intersects_aabb(&aabb));
+    /// ```
+    ///
+    /// [`Aabb`]: struct.Aabb.html
+    ///
+    fn intersects_aabb(&self, aabb: &Aabb<T, D>) -> bool;
+}
+
+impl<T: BHValue, const D: usize> IntersectsAabb<T, D> for Aabb<T, D> {
+    fn intersects_aabb(&self, aabb: &Aabb<T, D>) -> bool {
+        for i in 0..D {
+            if self.max[i] < aabb.min[i] || aabb.max[i] < self.min[i] {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl<T: BHValue, const D: usize> IntersectsAabb<T, D> for Point<T, D> {
+    fn intersects_aabb(&self, aabb: &Aabb<T, D>) -> bool {
+        aabb.contains(self)
+    }
+}

--- a/src/aabb/intersection.rs
+++ b/src/aabb/intersection.rs
@@ -34,12 +34,7 @@ pub trait IntersectsAabb<T: BHValue, const D: usize> {
 
 impl<T: BHValue, const D: usize> IntersectsAabb<T, D> for Aabb<T, D> {
     fn intersects_aabb(&self, aabb: &Aabb<T, D>) -> bool {
-        for i in 0..D {
-            if self.max[i] < aabb.min[i] || aabb.max[i] < self.min[i] {
-                return false;
-            }
-        }
-        true
+        self.intersects_aabb(aabb)
     }
 }
 

--- a/src/aabb/mod.rs
+++ b/src/aabb/mod.rs
@@ -1,0 +1,7 @@
+//! Axis Aligned Bounding Boxes.
+
+mod aabb_impl;
+mod intersection;
+
+pub use aabb_impl::*;
+pub use intersection::*;

--- a/src/ball.rs
+++ b/src/ball.rs
@@ -1,0 +1,118 @@
+//! Balls, including circles and spheres.
+
+use crate::{
+    aabb::{Aabb, IntersectsAabb},
+    bounding_hierarchy::BHValue,
+};
+use nalgebra::Point;
+
+/// In 2D, a circle. In 3D, a sphere. This can be used for traversing BVH's.
+pub struct Ball<T: BHValue, const D: usize> {
+    /// The center of the ball.
+    pub center: Point<T, D>,
+    /// The radius of the ball.
+    pub radius: T,
+}
+
+impl<T: BHValue, const D: usize> Ball<T, D> {
+    /// Creates a [`Ball`] with the given `center` and `radius`.
+    ///
+    /// # Panics
+    /// Panics, in debug mode, if the radius is negative.
+    ///
+    /// # Examples
+    /// ```
+    /// use bvh::ball::Ball;
+    /// use nalgebra::Point3;
+    ///
+    /// let ball = Ball::new(Point3::new(1.0, 1.0, 1.0), 1.0);
+    /// assert_eq!(ball.center, Point3::new(1.0, 1.0, 1.0));
+    /// assert_eq!(ball.radius, 1.0)
+    /// ```
+    ///
+    /// [`Ball`]: struct.Ball.html
+    pub fn new(center: Point<T, D>, radius: T) -> Self {
+        debug_assert!(radius >= T::from_f32(0.0).unwrap());
+        Self { center, radius }
+    }
+
+    /// Returns true if this [`Ball`] contains the [`Point`].
+    ///
+    /// # Examples
+    /// ```
+    /// use bvh::ball::Ball;
+    /// use nalgebra::Point3;
+    ///
+    /// let ball = Ball::new(Point3::new(1.0, 1.0, 1.0), 1.0);
+    /// let point = Point3::new(1.25, 1.25, 1.25);
+    ///
+    /// assert!(ball.contains(&point));
+    /// ```
+    ///
+    /// [`Ball`]: struct.Ball.html
+    pub fn contains(&self, point: &Point<T, D>) -> bool {
+        let mut distance_squared = T::zero();
+        for i in 0..D {
+            distance_squared += (point[i] - self.center[i]).powi(2);
+        }
+        // Squaring the RHS is faster than computing the square root of the LHS.
+        distance_squared <= self.radius.powi(2)
+    }
+
+    /// Returns true if this [`Ball`] intersects the [`Aabb`].
+    ///
+    /// # Examples
+    /// ```
+    /// use bvh::{aabb::Aabb, ball::Ball};
+    /// use nalgebra::Point3;
+    ///
+    /// let ball = Ball::new(Point3::new(1.0, 1.0, 1.0), 1.0);
+    /// let aabb = Aabb::with_bounds(Point3::new(1.25, 1.25, 1.25), Point3::new(3.0, 3.0, 3.0));
+    ///
+    /// assert!(ball.intersects_aabb(&aabb));
+    /// ```
+    ///
+    /// [`Aabb`]: struct.Aabb.html
+    /// [`Ball`]: struct.Ball.html
+    pub fn intersects_aabb(&self, aabb: &Aabb<T, D>) -> bool {
+        // https://gamemath.com/book/geomtests.html#intersection_sphere_aabb
+        // Finding the point in/on the AABB that is closest to the ball's center or,
+        // more specifically, find the squared distance between that point and the
+        // ball's center.
+        let mut distance_squared = T::zero();
+        for i in 0..D {
+            let closest_on_aabb = self.center[i].clamp(aabb.min[i], aabb.max[i]);
+            distance_squared += (closest_on_aabb - self.center[i]).powi(2);
+        }
+
+        // Then test if that point is in/on the ball. Squaring the RHS is faster than computing
+        // the square root of the LHS.
+        distance_squared <= self.radius.powi(2)
+    }
+}
+
+impl<T: BHValue, const D: usize> IntersectsAabb<T, D> for Ball<T, D> {
+    fn intersects_aabb(&self, aabb: &Aabb<T, D>) -> bool {
+        self.intersects_aabb(aabb)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Ball;
+    use crate::testbase::TPoint3;
+
+    #[test]
+    fn ball_contains() {
+        let ball = Ball::new(TPoint3::new(3.0, 4.0, 5.0), 1.5);
+
+        // Ball should contain its own center.
+        assert!(ball.contains(&ball.center));
+
+        // Test some manually-selected points.
+        let just_inside = TPoint3::new(3.04605, 3.23758, 3.81607);
+        let just_outside = TPoint3::new(3.06066, 3.15813, 3.70917);
+        assert!(ball.contains(&just_inside));
+        assert!(!ball.contains(&just_outside));
+    }
+}

--- a/src/ball.rs
+++ b/src/ball.rs
@@ -6,7 +6,14 @@ use crate::{
 };
 use nalgebra::Point;
 
-/// In 2D, a circle. In 3D, a sphere. This can be used for traversing BVH's.
+/// A circle, which can be used for traversing 2D BVHs.
+pub type Circle<T> = Ball<T, 2>;
+
+/// A sphere, which can be used for traversing 3D BVHs.
+pub type Sphere<T> = Ball<T, 3>;
+
+/// In 2D, a circle. In 3D, a sphere. This can be used for traversing BVHs.
+#[derive(Debug, Clone, Copy)]
 pub struct Ball<T: BHValue, const D: usize> {
     /// The center of the ball.
     pub center: Point<T, D>,

--- a/src/bounding_hierarchy.rs
+++ b/src/bounding_hierarchy.rs
@@ -5,11 +5,10 @@ use nalgebra::{
 };
 use num::{Float, FromPrimitive, Signed};
 
-use crate::aabb::Bounded;
+use crate::aabb::{Bounded, IntersectsAabb};
 #[cfg(feature = "rayon")]
 use crate::bvh::rayon_executor;
 use crate::bvh::BvhNodeBuildArgs;
-use crate::ray::Ray;
 
 /// Encapsulates the required traits for the value type used in the Bvh.
 pub trait BHValue:
@@ -240,9 +239,9 @@ pub trait BoundingHierarchy<T: BHValue, const D: usize> {
     /// [`BoundingHierarchy`]: trait.BoundingHierarchy.html
     /// [`Aabb`]: ../aabb/struct.Aabb.html
     ///
-    fn traverse<'a, Shape: BHShape<T, D>>(
+    fn traverse<'a, Query: IntersectsAabb<T, D>, Shape: BHShape<T, D>>(
         &'a self,
-        ray: &Ray<T, D>,
+        query: &Query,
         shapes: &'a [Shape],
     ) -> Vec<&'a Shape>;
 
@@ -258,12 +257,12 @@ impl<T: BHValue, const D: usize, H: BoundingHierarchy<T, D>> BoundingHierarchy<T
         Box::new(H::build(shapes))
     }
 
-    fn traverse<'a, Shape: BHShape<T, D>>(
+    fn traverse<'a, Query: IntersectsAabb<T, D>, Shape: BHShape<T, D>>(
         &'a self,
-        ray: &Ray<T, D>,
+        query: &Query,
         shapes: &'a [Shape],
     ) -> Vec<&'a Shape> {
-        H::traverse(self, ray, shapes)
+        H::traverse(self, query, shapes)
     }
 
     fn build_with_executor<

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,7 @@
 extern crate test;
 
 pub mod aabb;
+pub mod ball;
 pub mod bounding_hierarchy;
 pub mod bvh;
 pub mod flat_bvh;

--- a/src/ray/ray_impl.rs
+++ b/src/ray/ray_impl.rs
@@ -1,6 +1,7 @@
 //! This module defines a Ray structure and intersection algorithms
 //! for axis aligned bounding boxes and triangles.
 
+use crate::aabb::IntersectsAabb;
 use crate::utils::{fast_max, fast_min};
 use crate::{aabb::Aabb, bounding_hierarchy::BHValue};
 use nalgebra::{
@@ -350,6 +351,12 @@ mod tests {
                 assert!(intersection_inside || close_to_border);
             }
         }
+    }
+}
+
+impl<T: BHValue, const D: usize> IntersectsAabb<T, D> for Ray<T, D> {
+    fn intersects_aabb(&self, aabb: &Aabb<T, D>) -> bool {
+        self.intersects_aabb(aabb)
     }
 }
 


### PR DESCRIPTION
## Changes
- [x] Make traversal (normal and iterator, but not distance-based) generic **(breaking change)**
  - [x] Normal BVH
  - [x] Flat BVH
  - [x] `BoundingHierarchy` trait
  - [x] Traverse BVH by ray (existing feature maintained)
  - [x] Traverse BVH by point
  - [x] Traverse BVH by AABB
  - [x] Traverse BVH by ball (2d = circle, 3d = sphere)
- [x] Fuzz
- [x] Test
  - [x] `Ball::contains`
  - [x] `Aabb::intersects_aabb`
- [x] Documentation

## Questions
- [x] Would `IntersectsAabb` be a better name for `AabbIntersection`?
- [x] Is `Query` a good name for the `IntersectsAabb` generic?

## Related
Fixes #42
Fixes #45
Supersedes #43 (credit to @medakk for the central idea of this PR)
Related #71