### PR TITLE
Fix #120 - traverse single-node BVH

### DIFF
--- a/fuzz/fuzz_targets/fuzz.rs
+++ b/fuzz/fuzz_targets/fuzz.rs
@@ -256,7 +256,7 @@ impl<const D: usize> Workload<D> {
                 .traverse_iterator(&ray, &self.shapes)
                 .map(ByPtr)
                 .collect::<HashSet<_>>();
-            let _traverse_flat = flat_bvh
+            let traverse_flat = flat_bvh
                 .traverse(&ray, &self.shapes)
                 .into_iter()
                 .map(ByPtr)
@@ -264,8 +264,7 @@ impl<const D: usize> Workload<D> {
 
             if assert_traversal_agreement {
                 assert_eq!(traverse, traverse_iterator);
-                // TODO: Fails, due to bug(s) e.g. https://github.com/svenstaro/bvh/issues/120.
-                // assert_eq!(traverse, traverse_flat);
+                assert_eq!(traverse, traverse_flat);
             } else {
                 // Fails, probably due to normal rounding errors.
             }

--- a/src/bvh/bvh_impl.rs
+++ b/src/bvh/bvh_impl.rs
@@ -107,7 +107,7 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
             return Vec::new();
         }
         let mut indices = Vec::new();
-        BvhNode::traverse_recursive(&self.nodes, 0, ray, &mut indices);
+        BvhNode::traverse_recursive(&self.nodes, 0, shapes, ray, &mut indices);
         indices
             .iter()
             .map(|index| &shapes[*index])
@@ -454,7 +454,13 @@ pub fn rayon_executor<S, T: Send + BHValue, const D: usize>(
 
 #[cfg(test)]
 mod tests {
-    use crate::testbase::{build_empty_bh, build_some_bh, traverse_some_bh, TBvh3, TBvhNode3};
+    use crate::{
+        bounding_hierarchy::BoundingHierarchy,
+        testbase::{
+            build_empty_bh, build_some_bh, traverse_some_bh, TBvh3, TBvhNode3, TPoint3, TRay3,
+            TVector3, UnitBox,
+        },
+    };
 
     #[test]
     /// Tests whether the building procedure succeeds in not failing.
@@ -556,6 +562,33 @@ mod tests {
         }
 
         assert_eq!(expected_shapes, found_shapes);
+    }
+
+    /// A single-node BVH is special, since the root node is a leaf node. Make sure
+    /// the root node isn't unconditionally returned when it isn't intersected.
+    #[test]
+    fn test_traverse_one_node_bvh_no_intersection() {
+        let mut boxes = vec![UnitBox::new(0, TPoint3::new(0.0, 1.0, 2.0))];
+        let ray = TRay3::new(TPoint3::new(0.0, 0.0, 0.0), TVector3::new(1.0, 0.0, 0.0));
+        let bvh = TBvh3::build(&mut boxes);
+
+        assert!(bvh.traverse(&ray, &boxes).is_empty());
+        assert!(bvh.traverse_iterator(&ray, &boxes).next().is_none());
+        assert!(bvh.nearest_traverse_iterator(&ray, &boxes).next().is_none());
+        assert!(bvh.flatten().traverse(&ray, &boxes).is_empty())
+    }
+
+    /// Make sure the root node can be returned when it is intersected.
+    #[test]
+    fn test_traverse_one_node_bvh_intersection() {
+        let mut boxes = vec![UnitBox::new(0, TPoint3::new(10.0, 0.0, 0.0))];
+        let ray = TRay3::new(TPoint3::new(0.0, 0.0, 0.0), TVector3::new(1.0, 0.0, 0.0));
+        let bvh = TBvh3::build(&mut boxes);
+
+        assert_eq!(bvh.traverse(&ray, &boxes).len(), 1);
+        assert_eq!(bvh.traverse_iterator(&ray, &boxes).count(), 1);
+        assert_eq!(bvh.nearest_traverse_iterator(&ray, &boxes).count(), 1);
+        assert_eq!(bvh.flatten().traverse(&ray, &boxes).len(), 1)
     }
 }
 

--- a/src/bvh/distance_traverse.rs
+++ b/src/bvh/distance_traverse.rs
@@ -1,6 +1,6 @@
 use crate::aabb::Bounded;
 use crate::bounding_hierarchy::BHValue;
-use crate::bvh::{Bvh, BvhNode};
+use crate::bvh::{iter_initially_has_node, Bvh, BvhNode};
 use crate::ray::Ray;
 
 #[derive(Debug, Clone, Copy)]
@@ -50,7 +50,7 @@ where
             stack: [(0, RestChild::None); 32],
             node_index: 0,
             stack_size: 0,
-            has_node: !bvh.nodes.is_empty(),
+            has_node: iter_initially_has_node(bvh, ray, shapes),
         }
     }
 


### PR DESCRIPTION
Single-node BVH's are a special case since the root node is a leaf node. All traversal types, except flat, were unconditionally returning leaf nodes that they processed because they incorrectly assumed only intersected child leaf would be processed.

Fixes #120 and asserts, via the fuzzer, that traversal (which is now correct) agrees with flat traversal (which was correct).

Superficially conflicts with #128 and that PR is bigger, so recommend merging that PR first to make it easier to fix conflicts.