### PR TITLE
Bugfix #119 - distance traversal don't return non-hit shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 0.11.0 - 2025-??-??
+- **Breaking change:** BVH traversal now accepts a `Query: IntersectsAabb` rather than a `Ray`,
+  allowing points, AABB's, and circles/spheres to be tested, too. Most use-cases involving `Ray` 
+  will continue to compile as-is. If you previously wrote `BvhTraverseIterator<T, D, S>`, you'll
+  need to change it to `BvhTraverseIterator<T, D, Ray, S>`. [#128](https://github.com/svenstaro/bvh/pull/128) (thanks @finnbear)
+- **Breaking change:** Distance-traversal no longer outputs non-intersected shapes, but note that
+  `Ray::intersection_slice_for_aabb` now returns `None` instead of `(-1.0, -1.0)` in the case of no 
+  intersection, and `Some((entry, exit))` in the case of intersection. [#133](https://github.com/svenstaro/bvh/pull/133) (thanks @finnbear)
 - Fix panic on empty `DistanceTraverseIterator` [#117](https://github.com/svenstaro/bvh/pull/117) (thanks @finnbear)
 - Fix center() for very large AABBs [#118](https://github.com/svenstaro/bvh/pull/118) (thanks @finnbear)
 - Fix more cases where an empty BVH would panic [#116](https://github.com/svenstaro/bvh/pull/116) (thanks @finnbear)
 - Add fuzzing suite [#113](https://github.com/svenstaro/bvh/pull/113) (thanks @finnbear)
 - Fix some assertions [#129](https://github.com/svenstaro/bvh/pull/129) (thanks @finnbear)
 - Fix traversal in case of single-node BVH [#130](https://github.com/svenstaro/bvh/pull/130) (thanks @finnbear)
-- **Breaking change:** BVH traversal now accepts a `Query: IntersectsAabb` rather than a `Ray`,
-  allowing points, AABB's, and circles/spheres to be tested, too. Most use-cases involving `Ray` 
-  will continue to compile as-is. If you previously wrote `BvhTraverseIterator<T, D, S>`, you'll
-  need to change it to `BvhTraverseIterator<T, D, Ray, S>`. [#128](https://github.com/svenstaro/bvh/pull/128) (thanks @finnbear)
 - Fix intersection between rays and AABBs that lack depth. [#131](https://github.com/svenstaro/bvh/pull/131) (thanks @finnbear)
 
 ## 0.10.0 - 2024-07-06

--- a/fuzz/fuzz_targets/fuzz.rs
+++ b/fuzz/fuzz_targets/fuzz.rs
@@ -367,7 +367,7 @@ impl<const D: usize> Workload<D> {
             bvh.assert_tight();
             let flat_bvh = bvh.flatten();
 
-            let _traverse_ray = self.fuzz_traversal(
+            let traverse_ray = self.fuzz_traversal(
                 &bvh,
                 &flat_bvh,
                 &self.ray.ray(),
@@ -398,8 +398,7 @@ impl<const D: usize> Workload<D> {
                 .collect::<HashSet<_>>();
 
             if assert_ray_traversal_agreement {
-                // TODO: Fails, due to bug(s) e.g. https://github.com/svenstaro/bvh/issues/119
-                //assert_eq!(_traverse_ray, nearest_traverse_iterator);
+                assert_eq!(traverse_ray, nearest_traverse_iterator);
             } else {
                 // Fails, probably due to normal rounding errors.
             }


### PR DESCRIPTION
The old implementation of `Ray::intersection_slice_for_aabb` didn't correctly handle the special case of a ray parallel to sides of the AABB, which involves infinities.

- [x] Fix distance iterator
- [x] Deduplicates code of that iterator.
- [x] Breaking change in the signature of `Ray::intersection_slice_for_aabb` (`Option` is more idiomatic than `-1.0`)
- [x] Add a test case, which fails without the fix
- [x] Ensure that `Ray::intersection_slice_for_aabb` is still correct by either:
  - [x] testing that it still outputs the correct distance
![image](https://github.com/user-attachments/assets/1bb232df-55f5-49cf-b55d-2debe734ebff)
  - [ ] ~~making it private and changing the spec, so that only relative distance matters~~
- [x] Assert regular traversal = distance traversal in fuzzer (now all 5 traversal types are consistent :smile:)

Fixes #119

## Future work
- Write the Ray-AABB tmin/tmax calculation only once (internally using SIMD if enabled), not 3 times