### PR TITLE
Docs #134 - acknowledge best-effort nature of dist traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix some assertions [#129](https://github.com/svenstaro/bvh/pull/129) (thanks @finnbear)
 - Fix traversal in case of single-node BVH [#130](https://github.com/svenstaro/bvh/pull/130) (thanks @finnbear)
 - Fix intersection between rays and AABBs that lack depth. [#131](https://github.com/svenstaro/bvh/pull/131) (thanks @finnbear)
+- Document the limitations of distance traversal best-effort ordering. [#135](https://github.com/svenstaro/bvh/pull/135) (thanks @finnbear)
 
 ## 0.10.0 - 2024-07-06
 - Don't panic when traversing empty BVH [#106](https://github.com/svenstaro/bvh/pull/106) (thanks @finnbear)

--- a/src/bvh/bvh_impl.rs
+++ b/src/bvh/bvh_impl.rs
@@ -133,6 +133,9 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
     /// Returns a subset of [`shape`], in which the [`Aabb`]s of the elements were hit by [`Ray`].
     /// Return in order from nearest to farthest for ray.
     ///
+    /// This is a best-effort function that orders interior parent nodes before ordering child
+    /// nodes, so the output is not necessarily perfectly sorted.
+    ///
     /// [`Bvh`]: struct.Bvh.html
     /// [`Aabb`]: ../aabb/struct.AABB.html
     ///
@@ -147,6 +150,9 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
     /// Creates a [`DistanceTraverseIterator`] to traverse the [`Bvh`].
     /// Returns a subset of [`Shape`], in which the [`Aabb`]s of the elements were hit by [`Ray`].
     /// Return in order from farthest to nearest for ray.
+    ///
+    /// This is a best-effort function that orders interior parent nodes before ordering child
+    /// nodes, so the output is not necessarily perfectly sorted.
     ///
     /// [`Bvh`]: struct.Bvh.html
     /// [`Aabb`]: ../aabb/struct.AABB.html

--- a/src/bvh/distance_traverse.rs
+++ b/src/bvh/distance_traverse.rs
@@ -11,7 +11,10 @@ enum RestChild {
 }
 
 /// Iterator to traverse a [`Bvh`] in order from nearest [`Aabb`] to farthest for [`Ray`],
-/// without memory allocations
+/// or vice versa, without memory allocations.
+///
+/// This is a best-effort iterator that orders interior parent nodes before ordering child
+/// nodes, so the output is not necessarily perfectly sorted.
 pub struct DistanceTraverseIterator<
     'bvh,
     'shape,


### PR DESCRIPTION
The iterator is indeed capable of returning things in a slightly-incorrect order. I don't see an efficient way to fix it, and it may not matter for users, so this PR documents the limitation as-is.

Fixes #134