### PR TITLE
Update to `num@0.4.3` for `Float::clamp`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ approx = "0.5"
 rand = "0.8"
 log = "0.4"
 serde = { optional = true, version = "1", features = ["derive"] }
-num = "0.4.0"
+num = "0.4.3"
 nalgebra = { version = "0.33.0", features = ["default", "serde-serialize"] }
 rayon = {optional = true, version = "1.8.1" }
 


### PR DESCRIPTION
#128 requires `num_traits::Float::clamp`, which was [added very recently](https://github.com/rust-num/num-traits/pull/305).

`num@0.4.3` requires `num-traits@0.2.19` which is sufficient.