### PR TITLE
Bugfix #140 - no intersection slice on NaN.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   need to change it to `BvhTraverseIterator<T, D, Ray, S>`. [#128](https://github.com/svenstaro/bvh/pull/128) (thanks @finnbear)
 - **Breaking change:** Distance-traversal no longer outputs non-intersected shapes, but note that
   `Ray::intersection_slice_for_aabb` now returns `None` instead of `(-1.0, -1.0)` in the case of no 
-  intersection, and `Some((entry, exit))` in the case of intersection. [#133](https://github.com/svenstaro/bvh/pull/133) (thanks @finnbear)
+  intersection, and `Some((entry, exit))` in the case of intersection. [#133](https://github.com/svenstaro/bvh/pull/133) [#142](https://github.com/svenstaro/bvh/pull/142) (thanks @finnbear)
 - Fix panic on empty `DistanceTraverseIterator` [#117](https://github.com/svenstaro/bvh/pull/117) (thanks @finnbear)
 - Fix center() for very large AABBs [#118](https://github.com/svenstaro/bvh/pull/118) (thanks @finnbear)
 - Fix more cases where an empty BVH would panic [#116](https://github.com/svenstaro/bvh/pull/116) (thanks @finnbear)

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "bvh-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/src/ray/ray_impl.rs
+++ b/src/ray/ray_impl.rs
@@ -1,6 +1,8 @@
 //! This module defines a Ray structure and intersection algorithms
 //! for axis aligned bounding boxes and triangles.
 
+use std::cmp::Ordering;
+
 use crate::aabb::IntersectsAabb;
 use crate::utils::fast_max;
 use crate::{aabb::Aabb, bounding_hierarchy::BHValue};
@@ -124,15 +126,15 @@ impl<T: BHValue, const D: usize> Ray<T, D> {
 
         let (inf, sup) = lbr.inf_sup(&rtr);
 
-        let tmin = inf.max();
+        let tmin = fast_max(inf.max(), T::zero());
         let tmax = sup.min();
 
-        // no intersection
-        if tmin > tmax || tmax < T::zero() {
+        if matches!(tmin.partial_cmp(&tmax), Some(Ordering::Greater) | None) {
+            // tmin > tmax or either was NaN, meaning no intersection.
             return None;
         }
 
-        Some((fast_max(tmin, T::zero()), tmax))
+        Some((tmin, tmax))
     }
 
     /// Implementation of the


### PR DESCRIPTION
Fixes #140 by making `Ray::intersection_slice_for_aabb` agree with `Ray::intersects_aabb` that no intersection occurs when NaN is present (which happens when a ray starts in the plane of an AABB face and is tangent to that face).

- [x] Fuzz

<sup>I intend to merge this later, to allow for comments/suggestions/objections, and to avoid inducing conflicts in larger PR(s).</sup>