### PR TITLE
Fix #140 part 2 - detect NaN when intersection ray with AABB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix intersection between rays and AABBs that lack depth. [#131](https://github.com/svenstaro/bvh/pull/131) (thanks @finnbear)
 - Document the limitations of distance traversal best-effort ordering. [#135](https://github.com/svenstaro/bvh/pull/135) (thanks @finnbear)
 - Add `Bvh::nearest_to`, which returns the nearest shape to a point. [#108](https://github.com/svenstaro/bvh/pull/108) (thanks @Azkellas)
+- Fix ray-AABB intersection such that a ray in the plane of an AABB face is never
+  considered intersecting, rather than returning an arbitrary answer in the case of
+  `Ray::intersects_aabb` or an erroneous answer in the case of
+  `Ray::intersection_slice_for_aabb`. [#149](https://github.com/svenstaro/bvh/pull/149) (thanks @finnbear)
 
 ## 0.10.0 - 2024-07-06
 - Don't panic when traversing empty BVH [#106](https://github.com/svenstaro/bvh/pull/106) (thanks @finnbear)

--- a/fuzz/fuzz_targets/fuzz.rs
+++ b/fuzz/fuzz_targets/fuzz.rs
@@ -381,13 +381,27 @@ impl<const D: usize> Workload<D> {
         let ray = self.ray.ray();
         let aabb = self.aabb.aabb();
 
-        // Make sure these functions agree and that the latter doesn't return NaN.
+        // Make sure these functions agree and that the latter doesn't return NaN/infinity.
         let intersects = ray.intersects_aabb(&aabb);
         if let Some((entry, exit)) = ray.intersection_slice_for_aabb(&aabb) {
-            assert!(intersects);
-            assert!(entry <= exit, "{entry} {exit}");
+            assert!(
+                intersects,
+                "intersection_slice_for_aabb returned Some for non-intersection"
+            );
+            assert!(entry >= 0.0, "entry ({entry}) must be non-negative");
+            assert!(
+                entry <= exit,
+                "entry ({entry}) must not exceed exit ({exit})"
+            );
+            assert!(
+                entry.is_finite() && exit.is_finite(),
+                "neither entry ({entry}) nor exit ({exit}) may be infinite or NaN for AABB's and rays with finite coordinates"
+            );
         } else {
-            assert!(!intersects);
+            assert!(
+                !intersects,
+                "intersection_slice_for_aabb returned None for intersection"
+            );
         }
 
         // If this environment variable is present, only test limited-size BVH's without mutations.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,6 +5,7 @@ use crate::bvh::ShapeIndex;
 use crate::{aabb::Aabb, bvh::Shapes};
 
 use nalgebra::Scalar;
+use num::Float;
 
 /// Fast floating point minimum.  This function matches the semantics of
 ///
@@ -113,4 +114,10 @@ pub(crate) fn joint_aabb_of_shapes<T: BHValue, const D: usize, Shape: BHShape<T,
         centroid.grow_mut(&shape.aabb().center());
     }
     (aabb, centroid)
+}
+
+/// Returns `true` if and only if any of the floats returned by `iter` are NaN.
+#[inline(always)]
+pub(crate) fn has_nan<'a, T: Float + 'a>(iter: impl IntoIterator<Item = &'a T>) -> bool {
+    iter.into_iter().any(|f| f.is_nan())
 }


### PR DESCRIPTION
I got a bit distracted over the past week but, when I took a look this afternoon, I found a complete solution for #140.

The change is to consider all rays that are in the plane of an AABB face as non-intersecting with the AABB, by detecting NaN. Previously, a subset of those rays were intersecting, typically with NaN/infinity/finite-but-wrong intersection slices. It seems very difficult to assign a correct intersection slice to those rays.

A NaN results when a coordinate of the ray origin matches the corresponding coordinate of an AABB face AND the ray's direction has a value of 0 for that axis. This causes 0/0 = NaN, which is detectable.

## Testing
- [x] The included test fails without this change
- [x] The included fuzzer change fails without this change

## Benchmarking
I made some effort to optimize the code. Here is a quick benchmark:
### No SIMD
```
cargo bench --features bench -- bench_intersect_12k_triangles_bvh
before: 363.77ns
after: 382.76ns
regression: 5.2%
```
### SIMD
```
cargo bench --features bench,simd -- bench_intersect_12k_triangles_bvh
before: 294.96ns
after: 304.78ns
regression: 3.3%
```

Fixes #140 (again)