### PR TITLE
Avoid spurious failure in `nearest_to` fuzzer

### DIFF
--- a/fuzz/fuzz_targets/fuzz.rs
+++ b/fuzz/fuzz_targets/fuzz.rs
@@ -353,7 +353,9 @@ impl<const D: usize> Workload<D> {
         // assert_eq!(best, flat_best);
         // as such we only assert for distance equivalence if they are not None
         if let Some((best, flat_best)) = best.zip(flat_best) {
-            approx::assert_abs_diff_eq!(best.1, flat_best.1);
+            const EPSILON: f32 = 0.001;
+
+            approx::assert_abs_diff_eq!(best.1, flat_best.1, epsilon = EPSILON);
 
             // Brute force search for the ground truth, shapes is not empty since the results are not None.
             let mut bruteforce = (
@@ -368,8 +370,8 @@ impl<const D: usize> Workload<D> {
             }
             bruteforce = (bruteforce.0, bruteforce.1.sqrt());
             // Again we only test for distances.
-            approx::assert_abs_diff_eq!(best.1, bruteforce.1);
-            approx::assert_abs_diff_eq!(flat_best.1, bruteforce.1);
+            approx::assert_abs_diff_eq!(best.1, bruteforce.1, epsilon = EPSILON);
+            approx::assert_abs_diff_eq!(flat_best.1, bruteforce.1, epsilon = EPSILON);
         }
     }
 


### PR DESCRIPTION
Fixes a rare issue with the `nearest_to` fuzzer.

```
 thread '<unnamed>' panicked at fuzz_targets/fuzz.rs:356:13:
assert_abs_diff_eq!(best.1, flat_best.1)

    left  = 0.0003059545
    right = 0.00030377653
```
https://github.com/svenstaro/bvh/actions/runs/12971033150/job/36176984562?pr=149