### PR TITLE
Aligned x86_64 SIMD

### DIFF
--- a/justfile
+++ b/justfile
@@ -21,9 +21,13 @@ clippy:
     cargo clippy
     cargo clippy --manifest-path fuzz/Cargo.toml
 
-# test default features
+# test (default features)
 test:
     cargo test
+
+# test (with SIMD)
+test_simd:
+    cargo test --features simd
 
 # run benchmarks (without SIMD)
 bench:


### PR DESCRIPTION
Fixes #151 the easy way.

- [x] Benchmarks, just in case
<details>
<summary>Before</summary>

```
test bvh::bvh_impl::bench::bench_intersect_1200_triangles_bvh                 ... bench:         238.11 ns/iter (+/- 66.79)
test bvh::bvh_impl::bench::bench_intersect_120k_triangles_bvh                 ... bench:       1,370.12 ns/iter (+/- 149.45)
test bvh::bvh_impl::bench::bench_intersect_12k_triangles_bvh                  ... bench:         731.29 ns/iter (+/- 741.11)
```
</details>

<details>
<summary>After</summary>

```
test bvh::bvh_impl::bench::bench_intersect_1200_triangles_bvh                 ... bench:         247.19 ns/iter (+/- 22.44)
test bvh::bvh_impl::bench::bench_intersect_120k_triangles_bvh                 ... bench:       1,471.40 ns/iter (+/- 206.43)
test bvh::bvh_impl::bench::bench_intersect_12k_triangles_bvh                  ... bench:         636.56 ns/iter (+/- 76.06)
```
</details>

Verdict: no effect on performance
- [ ] Changelog