### PR TITLE
Remove extra deps and put log behind feature flag.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,25 +16,28 @@ keywords = ["bvh", "bounding", "volume", "sah", "aabb"]
 license = "MIT"
 
 [dependencies]
-approx = "0.5"
-log = "0.4"
-serde = { optional = true, version = "1", features = ["derive"] }
-num = "0.4.3"
-nalgebra = { version = "0.33.0", features = ["default", "serde-serialize"] }
+log = { optional = true, version = "0.4" }
+nalgebra = { version = "0.33.0", default-features = false }
+num-traits = { version = "0.2.19", default-features = false, features = ["std"] }
 rayon = { optional = true, version = "1.8.1" }
-wide = "0.7.32"
+serde = { optional = true, version = "1", features = ["derive"] }
+wide = { version = "0.7.32", optional = true }
 
 [dev-dependencies]
-proptest = "1.0"
-obj-rs = "0.7"
-rand = "0.9"
-float_eq = "1"
+approx = "0.5"
 doc-comment = "0.3"
+float_eq = "1"
+nalgebra = "0.33.0"
+num = "0.4.3"
+obj-rs = "0.7"
+proptest = "1.0"
+rand = "0.9"
 
 [features]
-default = ["rayon"]
 bench = []
-simd = []
+default = ["rayon"]
+serde = ["dep:serde", "nalgebra/serde-serialize"]
+simd = ["wide"]
 
 [profile.release]
 lto = true

--- a/src/bounding_hierarchy.rs
+++ b/src/bounding_hierarchy.rs
@@ -4,7 +4,7 @@ use nalgebra::{
     ClosedAddAssign, ClosedDivAssign, ClosedMulAssign, ClosedSubAssign, Point, Scalar,
     SimdPartialOrd,
 };
-use num::{Float, FromPrimitive, Signed};
+use num_traits::{Float, FromPrimitive, Signed};
 
 use crate::aabb::{Bounded, IntersectsAabb};
 #[cfg(feature = "rayon")]

--- a/src/bvh/optimization.rs
+++ b/src/bvh/optimization.rs
@@ -9,8 +9,6 @@
 use crate::bounding_hierarchy::{BHShape, BHValue};
 use crate::bvh::*;
 
-use log::info;
-
 // TODO Consider: Instead of getting the scene's shapes passed, let leaf nodes store an `Aabb`
 // that is updated from the outside, perhaps by passing not only the indices of the changed
 // shapes, but also their new `Aabb`'s into update_shapes().
@@ -41,7 +39,8 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
         shapes: &[Shape],
     ) {
         let child_aabb = self.nodes[child_index].get_node_aabb(shapes);
-        info!("\tConnecting: {child_index} < {parent_index}.");
+        #[cfg(feature = "log")]
+        log::info!("\tConnecting: {child_index} < {parent_index}.");
         // Set parent's child aabb and index.
         match self.nodes[parent_index] {
             BvhNode::Node {
@@ -58,7 +57,8 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
                     *child_r_index = child_index;
                     *child_r_aabb = child_aabb;
                 }
-                info!("\t  {parent_index}'s new {child_aabb}");
+                #[cfg(feature = "log")]
+                log::info!("\t  {parent_index}'s new {child_aabb}");
             }
             // Assuming that our `Bvh` is correct, the parent cannot be a leaf.
             _ => unreachable!(),

--- a/src/flat_bvh.rs
+++ b/src/flat_bvh.rs
@@ -5,7 +5,7 @@ use crate::bvh::{Bvh, BvhNode};
 use crate::point_query::PointDistance;
 
 use nalgebra::Point;
-use num::Float;
+use num_traits::Float;
 
 /// A structure of a node of a flat [`Bvh`]. The structure of the nodes allows for an
 /// iterative traversal approach without the necessity to maintain a stack or queue.

--- a/src/ray/ray_impl.rs
+++ b/src/ray/ray_impl.rs
@@ -9,7 +9,7 @@ use crate::{aabb::Aabb, bounding_hierarchy::BHValue};
 use nalgebra::{
     ClosedAddAssign, ClosedMulAssign, ClosedSubAssign, ComplexField, Point, SVector, SimdPartialOrd,
 };
-use num::{Float, One, Zero};
+use num_traits::{Float, One, Zero};
 
 use super::intersect_default::RayIntersection;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use crate::bvh::ShapeIndex;
 use crate::{aabb::Aabb, bvh::Shapes};
 
 use nalgebra::Scalar;
-use num::Float;
+use num_traits::Float;
 
 /// Fast floating point minimum.  This function matches the semantics of
 ///


### PR DESCRIPTION
On my computer running `cargo clean && cargo build --no-default-features`
Before: ```Finished `dev` profile [unoptimized + debuginfo] target(s) in 10.07s```
After: ```Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.40s```
Which linearly follows the number of crates needed 39 -> 17.

The only API change is putting 2 log::info in bvh optimization behind a feature flag. These logging calls could also be removed if they aren't needed anymore.
