### PR TITLE
Replace `log` with optional `tracing`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT"
 
 [dependencies]
 approx = "0.5"
-log = "0.4"
+tracing = { optional = true, version = "0.1" }
 serde = { optional = true, version = "1", features = ["derive"] }
 num = "0.4.3"
 nalgebra = { version = "0.33.0", features = ["default", "serde-serialize"] }

--- a/src/bvh/optimization.rs
+++ b/src/bvh/optimization.rs
@@ -9,8 +9,6 @@
 use crate::bounding_hierarchy::{BHShape, BHValue};
 use crate::bvh::*;
 
-use log::info;
-
 // TODO Consider: Instead of getting the scene's shapes passed, let leaf nodes store an `Aabb`
 // that is updated from the outside, perhaps by passing not only the indices of the changed
 // shapes, but also their new `Aabb`'s into update_shapes().
@@ -41,7 +39,8 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
         shapes: &[Shape],
     ) {
         let child_aabb = self.nodes[child_index].get_node_aabb(shapes);
-        info!("\tConnecting: {child_index} < {parent_index}.");
+        #[cfg(feature = "tracing")]
+        tracing::info!("\tConnecting: {child_index} < {parent_index}.");
         // Set parent's child aabb and index.
         match self.nodes[parent_index] {
             BvhNode::Node {
@@ -58,7 +57,8 @@ impl<T: BHValue, const D: usize> Bvh<T, D> {
                     *child_r_index = child_index;
                     *child_r_aabb = child_aabb;
                 }
-                info!("\t  {parent_index}'s new {child_aabb}");
+                #[cfg(feature = "tracing")]
+                tracing::info!("\t  {parent_index}'s new {child_aabb}");
             }
             // Assuming that our `Bvh` is correct, the parent cannot be a leaf.
             _ => unreachable!(),


### PR DESCRIPTION
`tracing`'s output is conditional on a `tracing` subscriber or using the `log` feature of `tracing`. As a result, `tracing` macros can be used in more places, without fear of creating unwanted clutter. Making `log` optional is not as good, since that is a compile-time decision and tracing subscribers can be adjusted at runtime.

Note: optional is a compile time optimization, as tracing statements are inherently optional too.

## Alternative

If logging isn't considered useful for end users, it could be made a dev-dependency and log statements could be conditioned on `#[cfg(test)]`.