### PR TITLE
Bump nalgebra to 0.34.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ version = "0.11.0"
 edition = "2021"
 rust-version = "1.65" # may raise to versions that are at least 1y old.
 authors = [
-    "Sven-Hendrik Haase <svenstaro@gmail.com>",
-    "Alexander Dmitriev <alexander.dmitriev2580@gmail.com>",
-    "Marios Staikopoulos <marstaik@gmail.com>",
+  "Sven-Hendrik Haase <svenstaro@gmail.com>",
+  "Alexander Dmitriev <alexander.dmitriev2580@gmail.com>",
+  "Marios Staikopoulos <marstaik@gmail.com>",
 ]
 readme = "README.md"
 repository = "https://github.com/svenstaro/bvh"
@@ -18,7 +18,7 @@ license = "MIT"
 [dependencies]
 serde = { optional = true, version = "1", features = ["derive"] }
 num-traits = "0.2.19"
-nalgebra = { version = "0.33.0", features = ["default", "serde-serialize"] }
+nalgebra = { version = "0.34.0", features = ["default", "serde-serialize"] }
 rayon = { optional = true, version = "1.8.1" }
 wide = { optional = true, version = "0.7.32" }
 


### PR DESCRIPTION
I love this project... It is really useful.

I have to backoff my version of nalgebra to use this crate.

This is open source .. and so in the spirit of "Talk is cheap, send patches".

here it is.